### PR TITLE
Fix LP bug 1243827

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -350,6 +350,20 @@ var unmarshalTests = []struct {
 			C inlineB `yaml:",inline"`
 		}{1, inlineB{2, inlineC{3}}},
 	},
+
+	// bug 1243827
+	{
+		"a: -b_c",
+		map[string]interface{}{"a": "-b_c"},
+	},
+	{
+		"a: +b_c",
+		map[string]interface{}{"a": "+b_c"},
+	},
+	{
+		"a: 50cent_of_dollar",
+		map[string]interface{}{"a": "50cent_of_dollar"},
+	},
 }
 
 type inlineB struct {

--- a/resolve.go
+++ b/resolve.go
@@ -113,13 +113,8 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 
 	case 'D', 'S':
 		// Int, float, or timestamp.
-		for i := 0; i != len(in); i++ {
-			if in[i] == '_' {
-				in = strings.Replace(in, "_", "", -1)
-				break
-			}
-		}
-		intv, err := strconv.ParseInt(in, 0, 64)
+		plain := strings.Replace(in, "_", "", -1)
+		intv, err := strconv.ParseInt(plain, 0, 64)
 		if err == nil {
 			if intv == int64(int(intv)) {
 				return "!!int", int(intv)
@@ -127,17 +122,17 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 				return "!!int", intv
 			}
 		}
-		floatv, err := strconv.ParseFloat(in, 64)
+		floatv, err := strconv.ParseFloat(plain, 64)
 		if err == nil {
 			return "!!float", floatv
 		}
-		if strings.HasPrefix(in, "0b") {
-			intv, err := strconv.ParseInt(in[2:], 2, 64)
+		if strings.HasPrefix(plain, "0b") {
+			intv, err := strconv.ParseInt(plain[2:], 2, 64)
 			if err == nil {
 				return "!!int", int(intv)
 			}
-		} else if strings.HasPrefix(in, "-0b") {
-			intv, err := strconv.ParseInt(in[3:], 2, 64)
+		} else if strings.HasPrefix(plain, "-0b") {
+			intv, err := strconv.ParseInt(plain[3:], 2, 64)
 			if err == nil {
 				return "!!int", -int(intv)
 			}


### PR DESCRIPTION
If the text of a scalar node of the parsed tree starts with a digit or '+' or '-', the function resolve() removes all '_' from it and tries to convert the new string into a float or integer. When this fails, the variant without the '_' was returned as a string value, which is obviously wrong.

I also removed the loop where strings.Replace(in, "_", "", -1) was called with a with a simple call of replace(). This should have the same result.

The changes in this request do not explain how the workaround mentioned in the bug report worked: strings.Replace() just removes _all_ underscores -- this affects double underscores as well as single underscores. Also, I was not able to reproduce it, neither with the current versions of yaml and juju-core nor with the juju-core version from the "stable" PPA for precise.
