### PR TITLE
Use TextMarshaler and Text.Unmarshaler in go-yaml

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"encoding"
 	"encoding/base64"
 	"fmt"
 	"reflect"
@@ -343,6 +344,12 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 				failf("!!binary value contains invalid base64 data")
 			}
 			resolved = string(data)
+		}
+	}
+	if out.Kind() != reflect.Ptr && out.CanAddr() {
+		if textu, ok := out.Addr().Interface().(encoding.TextUnmarshaler); ok {
+			err := textu.UnmarshalText([]byte(n.value))
+			return err == nil
 		}
 	}
 	if resolved == nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -5,6 +5,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 	"math"
+	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -418,6 +419,18 @@ var unmarshalTests = []struct {
 		"a: {b: c}",
 		M{"a": M{"b": "c"}},
 	},
+	// net.IP is an encoding.TextUnMarshaler.
+	{
+		"a: 127.0.0.1\n",
+		map[string]net.IP{"a": net.IPv4(127, 0, 0, 1)},
+	}, {
+		"a: 127.0.0.1\n",
+		&struct{ A *net.IP }{ipPtr(net.IPv4(127, 0, 0, 1))},
+	},
+}
+
+func ipPtr(ip net.IP) *net.IP {
+	return &ip
 }
 
 type M map[interface{}]interface{}

--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"encoding"
 	"reflect"
 	"regexp"
 	"sort"
@@ -72,6 +73,14 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 			return
 		}
 		in = reflect.ValueOf(v)
+	}
+	if m, ok := in.Interface().(encoding.TextMarshaler); ok {
+		v, err := m.MarshalText()
+		if err != nil {
+			fail(err)
+		}
+		e.stringv(tag, reflect.ValueOf(string(v)))
+		return
 	}
 	switch in.Kind() {
 	case reflect.Interface:

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,7 @@ package yaml_test
 import (
 	"fmt"
 	"math"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -259,6 +260,12 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "你好"},
 		"a: 你好\n",
+	},
+
+	// net.IP is an encoding.TextMarshaler.
+	{
+		map[string]net.IP{"a": net.IPv4(127, 0, 0, 1)},
+		"a: 127.0.0.1\n",
 	},
 }
 


### PR DESCRIPTION
Fixes issue #38. Using net.IP for the tests since it implements those interfaces.
