### PR TITLE
Fixes TypeError check in Unmarshal

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -90,7 +90,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 		}
 		d.unmarshal(node, v)
 	}
-	if d.terrors != nil {
+	if len(d.terrors) > 0 {
 		return &TypeError{d.terrors}
 	}
 	return nil


### PR DESCRIPTION
decoder.terrors can be empty but non-nil if the unmarshaler function is called multiple times in UnmarshalYAML.
This fixes the case where d.terrors is empty but has a non-zero capacity, which previously resulted in returning a TypeError with an empty list of error strings.
