### PR TITLE
Fix: Call UnmarshalYAML on literal empty string values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -31,9 +31,9 @@ type node struct {
 // Parser, produces a node tree out of a libyaml event stream.
 
 type parser struct {
-	parser  yaml_parser_t
-	event   yaml_event_t
-	doc     *node
+	parser yaml_parser_t
+	event  yaml_event_t
+	doc    *node
 }
 
 func newParser(b []byte) *parser {
@@ -193,10 +193,10 @@ type decoder struct {
 }
 
 var (
-	mapItemType = reflect.TypeOf(MapItem{})
-	durationType = reflect.TypeOf(time.Duration(0))
+	mapItemType    = reflect.TypeOf(MapItem{})
+	durationType   = reflect.TypeOf(time.Duration(0))
 	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
-	ifaceType = defaultMapType.Elem()
+	ifaceType      = defaultMapType.Elem()
 )
 
 func newDecoder() *decoder {
@@ -488,8 +488,6 @@ func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
 	}
 	return true
 }
-
-
 
 func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 	switch out.Kind() {

--- a/decode.go
+++ b/decode.go
@@ -248,9 +248,10 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 // unmarshalling was already done by UnmarshalYAML, and if so whether
 // its types unmarshalled appropriately.
 //
-// If n holds a null value, prepare returns before doing anything.
+// If n holds a null value, prepare returns before doing anything. However, if
+// n holds a literal empty string (i.e.: ""), prepare runs as usual.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "") {
+	if (n.tag == yaml_NULL_TAG) || (n.kind == scalarNode && n.tag == "" && (n.value == "null" || (n.value == "" && n.implicit))) {
 		return out, false, false
 	}
 	again := true

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,13 +2,14 @@ package yaml_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123

--- a/decode_test.go
+++ b/decode_test.go
@@ -765,6 +765,61 @@ func (s *S) TestUnmarshalNull(c *C) {
 	}
 }
 
+type StringStructContainer struct {
+	Val StringStruct
+}
+
+type StringStruct struct {
+	StrVal          string
+	UnmarshalCalled bool // to be able to check that UnmarshalYAML was actually called
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *StringStruct) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var value *string
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+	s.StrVal = *value
+	s.UnmarshalCalled = true
+	return nil
+}
+
+// If a node value is a literal empty string (i.e.: "") but the corresponding
+// object to Unmarshal to is a struct or a pointer to a struct, the struct must
+// have UnmarshalYAML() called on it with an empty string.
+func (s *S) TestUnmarshalEmptyStringToStruct(c *C) {
+	//j := []byte(`{"val": "null"}`)
+	// Literal empty string should call UnmarshalYAML.
+	j := []byte("val: \"\"\n")
+	v := new(StringStructContainer)
+	err := yaml.Unmarshal(j, v)
+	c.Assert(err, IsNil)
+	c.Assert(v.Val.StrVal, Equals, "")
+	c.Assert(v.Val.UnmarshalCalled, Equals, true)
+}
+
+func (s *S) TestUnmarshalNullStringToStruct(c *C) {
+	// "null" string should not call UnmarshalYAML, but instead produce a zero object.
+	j := []byte("val: null\n")
+	v := new(StringStructContainer)
+	err := yaml.Unmarshal(j, v)
+	c.Assert(err, IsNil)
+	c.Assert(v.Val.StrVal, Equals, "")
+	c.Assert(v.Val.UnmarshalCalled, Equals, false)
+}
+
+// "Implicit" document ending should not call UnmarshalYAML, but instead produce a blank object.
+func (s *S) TestUnmarshalImplicitEndingToStruct(c *C) {
+	// "null" string should not call UnmarshalYAML, but instead produce a zero object.
+	j := []byte("val: \n")
+	v := new(StringStructContainer)
+	err := yaml.Unmarshal(j, v)
+	c.Assert(err, IsNil)
+	c.Assert(v.Val.StrVal, Equals, "")
+	c.Assert(v.Val.UnmarshalCalled, Equals, false)
+}
+
 //var data []byte
 //func init() {
 //	var err error


### PR DESCRIPTION
If you have the YAML `a: ""\n`, and the `a` field corresponds to a struct, UnmarshalYAML is not called on the struct. Instead, decoder.prepare(...) short-circuits and fails to parse with an error: `cannot unmarshal !!str``into <struct>`.

I've added an example at the end of decode_test.go, but a practical example exists in the [Kubernetes project struct util.IntOrString](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/util/util.go#L63). With IntOrString, a YAML value turns into an IntOrString object which is created and filled in differently whether the value is an int or string in the YAML. So, `a: ""\n` and `a: 0\n` should both have UnmarshalYAML called on an IntOrString object, but `a: null\n` and `a: \n` both should have a zeroed out IntOrString object automatically created (or a nil pointer if the type is *IntOrString).

YAML v1 has the correct behavior since `a: ""\n` results in a call to UnmarshalYAML, and `a: null\n` and `a: \n` result in zeroed objects. This change breaks no existing tests and fixes the v2 regression. This change is also necessary for Kubernetes to upgrade from YAML v1 to v2 - see GoogleCloudPlatform/kubernetes#2490.
