### PR TITLE
Don't call MarshalText() if MarshalYAML() has been called

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -74,8 +74,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 			return
 		}
 		in = reflect.ValueOf(v)
-	}
-	if m, ok := iface.(encoding.TextMarshaler); ok {
+	} else if m, ok := iface.(encoding.TextMarshaler); ok {
 		text, err := m.MarshalText()
 		if err != nil {
 			fail(err)


### PR DESCRIPTION
I found a really nasty bug where, if you have an object that implements both yaml.Unmarshaler and encoding.TextMarshaler, both are called back-to-back, creating incorrect output. This patch fixes it, with tests, and without breaking any existing tests.
