### PR TITLE
runs 'gofmt -w *.go' on gopkg.in/yaml.v2

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -32,9 +32,9 @@ type node struct {
 // Parser, produces a node tree out of a libyaml event stream.
 
 type parser struct {
-	parser  yaml_parser_t
-	event   yaml_event_t
-	doc     *node
+	parser yaml_parser_t
+	event  yaml_event_t
+	doc    *node
 }
 
 func newParser(b []byte) *parser {
@@ -194,10 +194,10 @@ type decoder struct {
 }
 
 var (
-	mapItemType = reflect.TypeOf(MapItem{})
-	durationType = reflect.TypeOf(time.Duration(0))
+	mapItemType    = reflect.TypeOf(MapItem{})
+	durationType   = reflect.TypeOf(time.Duration(0))
 	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
-	ifaceType = defaultMapType.Elem()
+	ifaceType      = defaultMapType.Elem()
 )
 
 func newDecoder() *decoder {
@@ -502,8 +502,6 @@ func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
 	}
 	return true
 }
-
-
 
 func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 	switch out.Kind() {

--- a/yaml.go
+++ b/yaml.go
@@ -32,7 +32,6 @@ type Unmarshaler interface {
 	UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
-
 // The Marshaler interface may be implemented by types to customize their
 // behavior when being marshaled into a YAML document. The returned value
 // is marshaled in place of the original value implementing Marshaler.
@@ -164,7 +163,7 @@ func fail(err error) {
 }
 
 func failf(format string, args ...interface{}) {
-	panic(yamlError{fmt.Errorf("yaml: " + format, args...)})
+	panic(yamlError{fmt.Errorf("yaml: "+format, args...)})
 }
 
 // A TypeError is returned by Unmarshal when one or more fields in

--- a/yamlh.go
+++ b/yamlh.go
@@ -296,7 +296,7 @@ const (
 
 	// Not in original libyaml.
 	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
-	yaml_MERGE_TAG = "tag:yaml.org,2002:merge"
+	yaml_MERGE_TAG  = "tag:yaml.org,2002:merge"
 
 	yaml_DEFAULT_SCALAR_TAG   = yaml_STR_TAG // The default scalar tag is !!str.
 	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG // The default sequence tag is !!seq.


### PR DESCRIPTION
Runs "gofmt -w *.go" on the gopkg.in/yaml.v2 package.
