### PR TITLE
New regexp flag, checks for bad yaml tags, bug in usage of UnmarshalYAML

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+go-yaml Contributor List (ordered by date):
+
+Gustavo Niemeyer <gustavo@niemeyer.net>
+Dave Cheney <dave@cheney.net>
+John Arbash Meinel [https://github.com/jameinel]
+Roger Peppe [https://github.com/rogpeppe]
+Abel Deuring [https://github.com/adeuring]
+Jordan Liggitt [https://github.com/liggitt]
+Alon Diamant <diamant.alon@gmail.com>
+
+All contributors that provided patches.
+If they are missing, please update this file.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If opened in a browser, the import path itself leads to the API documentation:
 
   * [https://gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)
 
+Additional information is available in the source files, specifically yaml.go.
+
 API stability
 -------------
 
@@ -67,32 +69,32 @@ b:
 
 type T struct {
         A string
-        B struct{C int; D []int ",flow"}
+        B struct{C int; D []int `yaml:",flow"`}
 }
 
 func main() {
         t := T{}
-    
+
         err := yaml.Unmarshal([]byte(data), &t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t:\n%v\n\n", t)
-    
+
         d, err := yaml.Marshal(&t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t dump:\n%s\n\n", string(d))
-    
+
         m := make(map[interface{}]interface{})
-    
+
         err = yaml.Unmarshal([]byte(data), &m)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- m:\n%v\n\n", m)
-    
+
         d, err = yaml.Marshal(&m)
         if err != nil {
                 log.Fatalf("error: %v", err)

--- a/yaml.go
+++ b/yaml.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -28,10 +29,36 @@ type MapItem struct {
 // method receives a function that may be called to unmarshal the original
 // YAML value into a field or variable. It is safe to call the unmarshal
 // function parameter more than once if necessary.
+// Generally, the idea is to call the method to unmarshal into a value of
+// the correct type, then use this unmarshalled value wherever you need to.
+//
+// For example:
+//
+//     type T struct {
+//         values map[string]int
+//         sum    int
+//     }
+//
+//     func (t *T) UnmarshalYAML(unmarshaler func(interface{}) error) error {
+//
+//         if err := unmarshaler(t.values); err != nil {
+//             return err
+//         }
+//
+//         for _, value := range t.values {
+//             t.sum += value
+//         }
+//
+//         return nil
+//     }
+//
+//     var t T
+//     yaml.Unmarshal([]byte("T:\n  a: 1\n  b: 2\n  c:3"), &t)
+//
+//
 type Unmarshaler interface {
 	UnmarshalYAML(unmarshal func(interface{}) error) error
 }
-
 
 // The Marshaler interface may be implemented by types to customize their
 // behavior when being marshaled into a YAML document. The returned value
@@ -74,8 +101,51 @@ type Marshaler interface {
 //     var t T
 //     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
-// See the documentation of Marshal for the format of tags and a list of
-// supported tag options.
+//
+// Another flag which is supported during umarshaling, but must be used on
+// its own, is:
+//
+//     regexp       Unmarshal all encountered YAML values with keys that
+//                  match the regular expression into the tagged field,
+//                  which must be a map or a slice of a type that the
+//                  YAML value should be unmarshaled into.
+//				    [Unmarshaling]
+//
+// For example:
+//
+//     type T struct {
+//         A int
+//         B int
+//         Numbers map[string]int `yaml:",regexp:num.*"`
+//         Phrases []string `yaml:",regexp:phr.*"`
+//     }
+//     var t T
+//     yaml.Unmarshal([]byte("a: 1\nb: 2\nnum1: 1\nnum2: 50\n" +
+//                           "phraseOne: to be or not to be\n" +
+//                           "phraseTwo: you can't touch my key!\n" +
+//                           "anotherKey: ThisValueWillNotBeUnmarshalled"), &t)
+//
+// You can also use the regexp flag to get all unmapped values into a map for
+// runtime usage:
+//
+//     type T struct {
+//         A int
+//         B int
+//         EverythingElse map[string]interface{} `yaml:",regexp:.*"`
+//     }
+//     var t T
+//     yaml.Unmarshal([]byte("a: 1\nb: 2\nnum1: 1\nnum2: 50\n" +
+//                           "anInteger: 111\n" +
+//                           "aFloat: 0.5555\n" +
+//                           "anotherKey: WhichIsAstring\n" +
+//                           "aSequence: [1, 2, 3]\n" +
+//                           "aMapping: {hello: world}"), &t)
+//
+// The resulting EverythingElse map will contain everything except the values of
+// a and b.
+//
+// See the documentation of Marshal for the format of additional tags and a list
+// of supported tag options.
 //
 func Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
@@ -90,7 +160,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 		}
 		d.unmarshal(node, v)
 	}
-	if d.terrors != nil {
+	if d.terrors != nil && len(d.terrors) > 0 {
 		return &TypeError{d.terrors}
 	}
 	return nil
@@ -113,16 +183,19 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Does not apply to zero valued structs.
+//     omitempty    Only include the field when marshaling if it's
+//                  not set to the zero value for the type or to empty
+//                  slices or maps. Does not apply to zero valued structs.
+//				    [Marshaling]
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps.
+//     flow         Use a flow style when marshaling (useful for structs,
+//                  sequences and maps.)
+//				    [Marshaling]
 //
 //     inline       Inline the struct it's applied to, so its fields
-//                  are processed as if they were part of the outer
-//                  struct.
+//                  are processed (during marshaling and unmarshaling)
+//                  as if they were part of the outer struct.
+// 					[Marshaling, Unmarshaling]
 //
 // In addition, if the key is "-", the field is ignored.
 //
@@ -164,7 +237,7 @@ func fail(err error) {
 }
 
 func failf(format string, args ...interface{}) {
-	panic(yamlError{fmt.Errorf("yaml: " + format, args...)})
+	panic(yamlError{fmt.Errorf("yaml: "+format, args...)})
 }
 
 // A TypeError is returned by Unmarshal when one or more fields in
@@ -187,19 +260,39 @@ func (e *TypeError) Error() string {
 // structInfo holds details for the serialization of fields of
 // a given struct.
 type structInfo struct {
+	Type       reflect.Type
 	FieldsMap  map[string]fieldInfo
 	FieldsList []fieldInfo
 
 	// InlineMap is the number of the field in the struct that
 	// contains an ,inline map, or -1 if there's none.
 	InlineMap int
+
+	// This a list of fields with regexps that are tested during unmarshaling,
+	// and when matched by a YAML key, will write the value to the designated
+	// field value. This is check from top to bottom, the first match wins.
+	// Exact key match (using FieldsMap) is checked before the regular
+	// expression phase.
+	RegexpFieldsList []fieldInfo
 }
 
 type fieldInfo struct {
-	Key       string
-	Num       int
+
+	// YAML key to use for marshaling/unmarshaling of this field
+	Key string
+
+	// Index of the field in the struct
+	Num int
+
+	// When marshaling, whether to omit this field when it is set to Zero
 	OmitEmpty bool
-	Flow      bool
+
+	// Whether to marhsal using the YAML flow style
+	Flow bool
+
+	// Regular expression that the YAML key must match for unmarshaling into
+	// this field
+	Regexp *regexp.Regexp
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -209,44 +302,116 @@ var structMap = make(map[reflect.Type]*structInfo)
 var fieldMapMutex sync.RWMutex
 
 func getStructInfo(st reflect.Type) (*structInfo, error) {
+
+	// Try and get the relevant structInfo
 	fieldMapMutex.RLock()
 	sinfo, found := structMap[st]
 	fieldMapMutex.RUnlock()
+
+	// Return it, if found
 	if found {
 		return sinfo, nil
 	}
 
+	// Otherwise, let's create it.
 	n := st.NumField()
 	fieldsMap := make(map[string]fieldInfo)
 	fieldsList := make([]fieldInfo, 0, n)
+	regexpFieldsList := make([]fieldInfo, 0)
 	inlineMap := -1
+
+	// Go over each field
 	for i := 0; i != n; i++ {
+
+		// Get the StructField
 		field := st.Field(i)
+
 		if field.PkgPath != "" {
-			continue // Private field
+			continue // Skip private fields
 		}
 
+		// Create a fieldInfo struct
 		info := fieldInfo{Num: i}
 
+		// Try and get the yaml tag from the field
 		tag := field.Tag.Get("yaml")
-		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
-			tag = string(field.Tag)
+
+		// An empty tag means a possibly badly formatted tag. We try and act nice
+		if tag == "" {
+
+			rawTagString := string(field.Tag)
+
+			if strings.Index(string(field.Tag), ":") < 0 {
+				// Handle tags with no yaml: prefix, just use the raw comment
+				// tag string
+				tag = rawTagString
+			} else if strings.HasPrefix(rawTagString, "yaml:") {
+				// Handle badly formatted yaml: tags (no quotes, for example)
+				failf("Detected badly formatted tag for field %s; missing quotes?\n",
+					field.Name)
+			}
+
+			// TODO: Consider whether we should be more strict:
+			// if tag != "" {
+			//     return nil,
+			//			  fmt.Errof("Badly formatted yaml tag detected: %s",
+			//					    string(field.Tag)
+			// }
 		}
+
+		// '-' means - skip this field
 		if tag == "-" {
 			continue
 		}
 
+		// First, try and see if we have a regexp flag set - if so, handle it.
+		if strings.HasPrefix(tag, ",regexp:") {
+
+			// Store just the pattern
+			regex := tag[8:]
+
+			// Compile parses a regular expression. Use it as the key in the
+			// hash.
+			compiledRegexp := regexp.MustCompile(regex)
+
+			// Verify that the type is indeed a map or a slice
+			if field.Type.Kind() != reflect.Map &&
+				field.Type.Kind() != reflect.Slice {
+
+				// Die
+				failf("field %s.%s has regexp flag set but is not a map or slice",
+					st.Name(), field.Name)
+			}
+
+			info.Regexp = compiledRegexp
+			regexpFieldsList = append(regexpFieldsList, info)
+			continue
+		}
+
+		// Try and see what flags are set
 		inline := false
-		fields := strings.Split(tag, ",")
-		if len(fields) > 1 {
+		if fields := strings.Split(tag, ","); len(fields) > 1 {
 			for _, flag := range fields[1:] {
 				switch flag {
+
+				// Only include the field if it's not set to the zero
+				// value for the type or to empty slices or maps.
+				// Does not apply to zero valued structs. [Marshaling]
 				case "omitempty":
 					info.OmitEmpty = true
+
+				// Marshal using a flow style (useful for structs, sequences and
+				// maps.) [Marshaling]
 				case "flow":
 					info.Flow = true
+
+				// Inline the struct it's applied to, so its fields are processed
+				// as if they were part of the outer struct.
+				// [Marshaling, Unmarshaling]
 				case "inline":
 					inline = true
+
+				// Unsupported flag?
 				default:
 					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
 				}
@@ -254,6 +419,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 			tag = fields[0]
 		}
 
+		// Handle the struct fields as if they were part of the outer struct.
 		if inline {
 			switch field.Type.Kind() {
 			// TODO: Implement support for inline maps.
@@ -291,25 +457,32 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		}
 
 		if tag != "" {
+			// If we have a yaml tag with a custom mapping key, then use it
 			info.Key = tag
 		} else {
+			// Otherwise, use the lower-case name of the field
 			info.Key = strings.ToLower(field.Name)
 		}
 
+		// Search for duplicate mapping keys, error if found
 		if _, found = fieldsMap[info.Key]; found {
 			msg := "Duplicated key '" + info.Key + "' in struct " + st.String()
 			return nil, errors.New(msg)
 		}
 
+		// Add the generated fieldInfo to the fields list and map
 		fieldsList = append(fieldsList, info)
 		fieldsMap[info.Key] = info
 	}
 
-	sinfo = &structInfo{fieldsMap, fieldsList, inlineMap}
+	// Create a new structInfo object, with all the metadata we collected
+	sinfo = &structInfo{st, fieldsMap, fieldsList, inlineMap, regexpFieldsList}
 
+	// Set it to the struct map, return it
 	fieldMapMutex.Lock()
 	structMap[st] = sinfo
 	fieldMapMutex.Unlock()
+
 	return sinfo, nil
 }
 


### PR DESCRIPTION
-  Added new regexp flag: Unmarshal all encountered YAML values with keys
  that match the regular expression into the tagged field of a struct,
  which must be a map or a slice of a type that the YAML value should
  be unmarshaled into. [Unmarshaling only]
-  Now dies in case of a badly formatted YAML tag in a struct field
-  Added CONTRIBUTORS file

Bugs:
-  When a type implementing UnmarshalYAML calls the the unmarshaler func()
  to unmarshal to a specific type, which fails, followed by it calling
  the func() again with a different output value which suceeds, the YAML
  unmarshaling process still failed. Issue was d.terrs == nil check, but
  not len(d.terrs) == 0

Tests:
-  Lots of new tests for the regexp flag - regexp unmarshaling into maps,
  slices, regexp priority etc.
