### PR TITLE
Don't fail if an Unmarshaler generates an intermediate error

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -32,7 +32,6 @@ type Unmarshaler interface {
 	UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
-
 // The Marshaler interface may be implemented by types to customize their
 // behavior when being marshaled into a YAML document. The returned value
 // is marshaled in place of the original value implementing Marshaler.
@@ -90,7 +89,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 		}
 		d.unmarshal(node, v)
 	}
-	if d.terrors != nil {
+	if len(d.terrors) != 0 {
 		return &TypeError{d.terrors}
 	}
 	return nil
@@ -164,7 +163,7 @@ func fail(err error) {
 }
 
 func failf(format string, args ...interface{}) {
-	panic(yamlError{fmt.Errorf("yaml: " + format, args...)})
+	panic(yamlError{fmt.Errorf("yaml: "+format, args...)})
 }
 
 // A TypeError is returned by Unmarshal when one or more fields in


### PR DESCRIPTION
When handling an `Unmarshaler`, the code slices any errors generated by the intermediate unmarshal call out of the parent `terrors` list. However, this results in the slice being non-nil, and so the root `Unmarshal` call will still fail with an empty error list, since it checks for non-nil, instead of nonzero length.
