### PR TITLE
Bug fixed: inner function inside UnmarshalYAML can be called several times

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -90,7 +90,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 		}
 		d.unmarshal(node, v)
 	}
-	if d.terrors != nil {
+	if len(d.terrors) != 0 {
 		return &TypeError{d.terrors}
 	}
 	return nil


### PR DESCRIPTION
When implementing interface Unmarshaler sometimes it's useful to call inner function several times. In this case slice terrors initialized and despite the fact that there are no errors, terrors is not nil (but has zero length). Because it's safe to call len() on variable of slice type which can be nil, It's better to check `len(v) != 0`  than `v != nil`.

Here is working example
https://gist.github.com/coxx/ae6bc531573d72fb4d62
