### PR TITLE
decode: add mapping key transform hook

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -32,13 +32,15 @@ type node struct {
 // Parser, produces a node tree out of a libyaml event stream.
 
 type parser struct {
-	parser yaml_parser_t
-	event  yaml_event_t
-	doc    *node
+	parser    yaml_parser_t
+	event     yaml_event_t
+	doc       *node
+	transform transformString
 }
 
-func newParser(b []byte) *parser {
-	p := parser{}
+func newParser(b []byte, t transformString) *parser {
+	p := parser{transform: t}
+
 	if !yaml_parser_initialize(&p.parser) {
 		panic("failed to initialize YAML emitter")
 	}
@@ -177,7 +179,10 @@ func (p *parser) mapping() *node {
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	for p.event.typ != yaml_MAPPING_END_EVENT {
-		n.children = append(n.children, p.parse(), p.parse())
+		key := p.parse()
+		key.value = p.transform(key.value)
+		value := p.parse()
+		n.children = append(n.children, key, value)
 	}
 	p.skip()
 	return n

--- a/decode_test.go
+++ b/decode_test.go
@@ -812,6 +812,23 @@ func (s *S) TestUnmarshalerRetry(c *C) {
 	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1}))
 }
 
+func (s *S) TestUnmarshalWithTransform(c *C) {
+	data := `{a_b: 1, c-d: 2, e-f_g: 3, h_i-j: 4}`
+	expect := map[string]int{
+		"a_b":   1,
+		"c_d":   2,
+		"e_f_g": 3,
+		"h_i_j": 4,
+	}
+	m := map[string]int{}
+	yaml.UnmarshalMappingKeyTransform = func(i string) string {
+		return strings.Replace(i, "-", "_", -1)
+	}
+	err := yaml.Unmarshal([]byte(data), m)
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, expect)
+}
+
 // From http://yaml.org/type/merge.html
 var mergeTests = `
 anchors:

--- a/yaml.go
+++ b/yaml.go
@@ -79,7 +79,7 @@ type Marshaler interface {
 func Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
 	d := newDecoder()
-	p := newParser(in)
+	p := newParser(in, UnmarshalMappingKeyTransform)
 	defer p.destroy()
 	node := p.parse()
 	if node != nil {
@@ -143,6 +143,17 @@ func Marshal(in interface{}) (out []byte, err error) {
 	e.finish()
 	out = e.out
 	return
+}
+
+// UnmarshalMappingKeyTransform is a string transformation that is applied to
+// each mapping key in a YAML document before it is unmarshalled. By default,
+// UnmarshalMappingKeyTransform is an identity transform (no modification).
+var UnmarshalMappingKeyTransform transformString = identityTransform
+
+type transformString func(in string) (out string)
+
+func identityTransform(in string) (out string) {
+	return in
 }
 
 func handleErr(err *error) {


### PR DESCRIPTION
This hook allows the user to apply a custom transform to mapping keys
during unmarshalling.
