### PR TITLE
#88 add a binary tag, so it can add git logbinary when marshal the yaml

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2,8 +2,8 @@ package yaml_test
 
 import (
 	"errors"
+	"github.com/datianshi/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"

--- a/encode.go
+++ b/encode.go
@@ -163,7 +163,11 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 			}
 			e.marshal("", reflect.ValueOf(info.Key))
 			e.flow = info.Flow
-			e.marshal("", value)
+			if info.Binary {
+				e.marshal(yaml_BINARY_TAG, value)
+			} else {
+				e.marshal("", value)
+			}
 		}
 		if sinfo.InlineMap >= 0 {
 			m := in.Field(sinfo.InlineMap)

--- a/encode.go
+++ b/encode.go
@@ -244,6 +244,9 @@ var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0
 func (e *encoder) stringv(tag string, in reflect.Value) {
 	var style yaml_scalar_style_t
 	s := in.String()
+	if tag == yaml_BINARY_TAG {
+		s = encodeBase64(s)
+	}
 	rtag, rs := resolve("", s)
 	if rtag == yaml_BINARY_TAG {
 		if tag == "" || tag == yaml_STR_TAG {

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datianshi/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"net"
 	"os"
 )
@@ -281,8 +281,8 @@ var marshalTests = []struct {
 	{
 		&struct {
 			A string `yaml:",binary"`
-		}{A: "SGVsbG8="},
-		"a: !!binary SGVsbG8=\n",
+		}{A: "hello"},
+		"a: !!binary aGVsbG8=\n",
 	},
 
 	// Ordered maps.

--- a/encode_test.go
+++ b/encode_test.go
@@ -278,6 +278,12 @@ var marshalTests = []struct {
 		map[string]string{"a": strings.Repeat("\x90", 54)},
 		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
 	},
+	{
+		&struct {
+			A string `yaml:",binary"`
+		}{A: "SGVsbG8="},
+		"a: !!binary SGVsbG8=\n",
+	},
 
 	// Ordered maps.
 	{
@@ -330,7 +336,7 @@ var marshalErrorTests = []struct {
 	panic: `Duplicated key 'b' in struct struct \{ B int; .*`,
 }, {
 	value: &struct {
-		A       int
+		A int
 		B map[string]int ",inline"
 	}{1, map[string]int{"a": 2}},
 	panic: `Can't have key "a" in inlined map; conflicts with struct field`,

--- a/yaml.go
+++ b/yaml.go
@@ -200,6 +200,7 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	Binary    bool
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -245,6 +246,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.OmitEmpty = true
 				case "flow":
 					info.Flow = true
+				case "binary":
+					info.Binary = true
 				case "inline":
 					inline = true
 				default:
@@ -330,7 +333,7 @@ func isZero(v reflect.Value) bool {
 		return !v.Bool()
 	case reflect.Struct:
 		vt := v.Type()
-		for i := v.NumField()-1; i >= 0; i-- {
+		for i := v.NumField() - 1; i >= 0; i-- {
 			if vt.Field(i).PkgPath != "" {
 				continue // Private field
 			}


### PR DESCRIPTION
This Is trying to resolve #88

type Test struct {
         TestString string `yaml:",binary"`
 }
         str := base64.StdEncoding.EncodeToString([]byte("sdfsf"))
         test := Test{
                 TestString: str,
          }
          data, err := yaml.Marshal(&test)
          if err != nil {
                  fmt.Println(err)
          }
          fmt.Println(string(data))

The above will output:

teststring: !!binary c2Rmc2Y=
