### PR TITLE
Do not process MapSlice keys as boolean

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -559,6 +559,12 @@ var unmarshalTests = []struct {
 		"a: []",
 		&struct{ A []int }{[]int{}},
 	},
+
+	// do not parse key as boolean keyword
+	{
+		"{on: 1, off: 2, true: 3, false: 4, yes: 5, no: 6}",
+		&yaml.MapSlice{{"on", 1}, {"off", 2}, {"true", 3}, {"false", 4}, {"yes", 5}, {"no", 6}},
+	},
 }
 
 type M map[interface{}]interface{}

--- a/yaml.go
+++ b/yaml.go
@@ -20,7 +20,8 @@ type MapSlice []MapItem
 
 // MapItem is an item in a MapSlice.
 type MapItem struct {
-	Key, Value interface{}
+	Key   string
+	Value interface{}
 }
 
 // The Unmarshaler interface may be implemented by types to customize their


### PR DESCRIPTION
Currently if a yaml will be unmarshalled as an MapSlice which contains a yaml boolean key words as a key, than the map will contain a boolean as identifier.

Example:

```
on: 1
```

Currently if unmarshalled into a MapSlice, this will become:

```
yaml.MapSlice{{true, 1}}
```

Expected or desired  is: 

```
yaml.MapSlice{{"on", 1}}
```

This change is not  backwards compatible: Current users might expect a numeric key to be unmarshalled into a interger though. However this change makes more sense, and probably is more inline with the spec, as there is no numeric key map in json/yaml.

If backwards compatibility is desired than a new type could be created with the current implementation of MapSlice (and MapSlice should be reverted, and documented concerning this issue)

yaml boolean key words: `on`, `off`, `true`, `false`, `no`, `yes`.
