### PR TITLE
Automatically decode embedded structs "inline"

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -936,6 +936,21 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 	c.Assert(v.A, DeepEquals, []int{2})
 }
 
+func (s *S) TestUnmarshalEmbeddedStructs(c *C) {
+	type Bar struct {
+		Name string
+	}
+
+	type Foo struct {
+		Address string
+		Bar
+	}
+
+	var g Foo
+	yaml.Unmarshal([]byte("---\nname: Deepak"), &g)
+	c.Assert(g.Name, Equals, "Deepak")
+}
+
 //var data []byte
 //func init() {
 //	var err error

--- a/yaml.go
+++ b/yaml.go
@@ -237,6 +237,11 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		}
 
 		inline := false
+		// a embedded struct is auto-inlined, see LP: #1191814
+		if field.Anonymous {
+			inline = true
+		}
+
 		fields := strings.Split(tag, ",")
 		if len(fields) > 1 {
 			for _, flag := range fields[1:] {


### PR DESCRIPTION
By adding "inline" automatically for embededed struct all (visible)
values from the embedded struct are read (this is what json is
doing). Fixes LP: #1191814
