### PR TITLE
Feature/embeded structs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The yaml package is licensed under the LGPL with an exception that allows it to 
 Example
 -------
 
+Some more examples can be found in the "examples" folder.
+
 ```Go
 package main
 

--- a/examples/embedded-structs.go
+++ b/examples/embedded-structs.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+        "gopkg.in/yaml.v2"
+)
+
+type StructA struct {
+	A string `yaml:"a"`
+}
+
+type StructB struct {
+	// go-yaml will not decode embedded structs by default, to do that
+	// you need to add the ",inline" annotation below
+	StructA   `yaml:",inline"`
+	B string `yaml:"b"`
+}
+
+var data = `
+a: a string from struct A
+b: a string from struct B
+`
+
+func main() {
+	var b StructB
+
+	err := yaml.Unmarshal([]byte(data), &b)
+	if err != nil {
+                log.Fatalf("error: %v", err)
+	}
+        fmt.Println(b.A)
+        fmt.Println(b.B)
+}


### PR DESCRIPTION
This branch adds a small example how to decode embedded structs to help users of the library to find this nice feature more easily.
