### PR TITLE
Use an svg icon for the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,16 @@ supported since they're a poor design and are gone in YAML 1.2.
 Installation and usage
 ----------------------
 
-The import path for the package is *gopkg.in/yaml.v2*.
+The import path for the package is `gopkg.in/yaml.v2`.
 
 To install it, run:
 
     go get gopkg.in/yaml.v2
 
-API documentation
------------------
+API
+---
 
-If opened in a browser, the import path itself leads to the API documentation:
-
-  * [https://gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)
-
-API stability
--------------
+[![GoDoc](http://godoc.org/gopkg.in/yaml.v2?status.svg)](http://godoc.org/gopkg.in/yaml.v2)
 
 The package API for yaml v2 will remain stable as described in [gopkg.in](https://gopkg.in).
 


### PR DESCRIPTION
Concatenate API documentation and API stability into one section.
Switch style for package name in Installation section.

Compare https://github.com/go-yaml/yaml/tree/v2 and https://github.com/maruel/yaml/tree/v2 for the look. I like the icon, it's easy to recognize and clicking on it always leads to the expected result: documentation.
