### PR TITLE
Fix bug in `yaml_emitter_analyze_scalar()` when the string starting with multi-byte character

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -1019,7 +1019,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 
 	preceeded_by_whitespace = true
 	for i, w := 0, 0; i < len(value); i += w {
-		w = width(value[0])
+		w = width(value[i])
 		followed_by_whitespace = i+w >= len(value) || is_blank(value, i+w)
 
 		if i == 0 {

--- a/encode_test.go
+++ b/encode_test.go
@@ -306,6 +306,16 @@ var marshalTests = []struct {
 		map[string]string{"a": "b: c"},
 		"a: 'b: c'\n",
 	},
+
+	// Containing hash mark ('#') in string should be quoted
+	{
+		map[string]string{"a": "Hello #comment"},
+		"a: 'Hello #comment'\n",
+	},
+	{
+		map[string]string{"a": "你好 #comment"},
+		"a: '你好 #comment'\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {


### PR DESCRIPTION
`width(value[0])` always returns the width of first character of the string. It should be `width(value[i])`.
