### PR TITLE
Fix for non-specific tags parsing

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -405,6 +405,12 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"v": 1},
 	},
 
+	// Non-specific tag (Issue #75)
+	{
+		"v: ! test",
+		map[string]interface{}{"v": "test"},
+	},
+
 	// Anchors and aliases.
 	{
 		"a: &x 1\nb: &y 2\nc: *x\nd: *y\n",

--- a/scannerc.go
+++ b/scannerc.go
@@ -611,7 +611,7 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 	if directive {
 		context = "while parsing a %TAG directive"
 	}
-	return yaml_parser_set_scanner_error(parser, context, context_mark, "did not find URI escaped octet")
+	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
 }
 
 func trace(args ...interface{}) func() {
@@ -1959,11 +1959,12 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
 	//size_t length = head ? strlen((char *)head) : 0
 	var s []byte
+	length := len(head)
 
 	// Copy the head if needed.
 	//
 	// Note that we don't copy the leading '!' character.
-	if len(head) > 1 {
+	if length > 0 {
 		s = append(s, head[1:]...)
 	}
 
@@ -1996,6 +1997,7 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 			}
 		} else {
 			s = read(parser, s)
+			length++
 		}
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false
@@ -2003,7 +2005,7 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 	}
 
 	// Check if the tag is non-empty.
-	if len(s) == 0 {
+	if length == 0 {
 		yaml_parser_set_scanner_tag_error(parser, directive,
 			start_mark, "did not find expected tag URI")
 		return false


### PR DESCRIPTION
Make it acting like libyaml which includes length of the head when testing for emptiness: https://github.com/yaml/libyaml/blob/master/src/scanner.c#L2582
