### PR TITLE
Expose line and column number of parsed elements

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -586,7 +586,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 			d.merge(n.children[i+1], out)
 			continue
 		}
-		item := MapItem{}
+		item := MapItem{Line: n.children[i].line, Col: n.children[i].column}
 		k := reflect.ValueOf(&item.Key).Elem()
 		if d.unmarshal(n.children[i], k) {
 			v := reflect.ValueOf(&item.Value).Elem()

--- a/decode.go
+++ b/decode.go
@@ -616,6 +616,17 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 		elemType = inlineMap.Type().Elem()
 	}
 
+	for _, f := range sinfo.FieldsMap {
+		if f.LineNum {
+			field := out.Field(f.Num)
+			field.SetInt(int64(n.line))
+		}
+		if f.ColNum {
+			field := out.Field(f.Num)
+			field.SetInt(int64(n.column))
+		}
+	}
+
 	for i := 0; i < l; i += 2 {
 		ni := n.children[i]
 		if isMerge(ni) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -529,9 +529,27 @@ var unmarshalTests = []struct {
 	// Ordered maps.
 	{
 		"{b: 2, a: 1, d: 4, c: 3, sub: {e: 5}}",
-		&yaml.MapSlice{{"b", 2}, {"a", 1}, {"d", 4}, {"c", 3}, {"sub", yaml.MapSlice{{"e", 5}}}},
+		&yaml.MapSlice{
+			{"b", 2, 0, 1},
+			{"a", 1, 0, 7},
+			{"d", 4, 0, 13},
+			{"c", 3, 0, 19},
+			{"sub", yaml.MapSlice{
+				{"e", 5, 0, 31},
+			}, 0, 25},
+		},
 	},
 
+	// Line numbers on ordered maps.
+	{
+		`root:
+  sub1: apple
+  sub2: orange`,
+		&yaml.MapSlice{{"root", yaml.MapSlice{
+			{"sub1", "apple", 1, 2},
+			{"sub2", "orange", 2, 2},
+		}, 0, 0}},
+	},
 	// Issue #39.
 	{
 		"a:\n b:\n  c: d\n",

--- a/decode_test.go
+++ b/decode_test.go
@@ -3,7 +3,7 @@ package yaml_test
 import (
 	"errors"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	yaml "."
 	"math"
 	"net"
 	"reflect"
@@ -810,6 +810,50 @@ func (s *S) TestUnmarshalerRetry(c *C) {
 	err = yaml.Unmarshal([]byte("1"), &su)
 	c.Assert(err, IsNil)
 	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1}))
+}
+
+type testPerson struct {
+	Name       string
+	Profession string
+	YOB        int
+
+	LineNumber int `,linenum`
+	ColNumber  int `,colnum`
+}
+
+func (s *S) TestUnmarshalerWithLineNumbers(c *C) {
+
+	input := []byte(`---
+- name: Ada Lovelace
+  profession: Mathematician
+  yob: 1815
+
+- name: Ada Rogato
+  profession: Pilot and Parachutist
+  yob: 1910
+`)
+
+	var v []testPerson
+	err := yaml.Unmarshal(input, &v)
+
+	c.Assert(err, IsNil)
+
+	c.Assert(v, DeepEquals, []testPerson{
+		testPerson{
+			Name:       "Ada Lovelace",
+			Profession: "Mathematician",
+			YOB:        1815,
+			LineNumber: 1,
+			ColNumber:  2,
+		},
+		testPerson{
+			Name:       "Ada Rogato",
+			Profession: "Pilot and Parachutist",
+			YOB:        1910,
+			LineNumber: 5,
+			ColNumber:  2,
+		},
+	})
 }
 
 // From http://yaml.org/type/merge.html

--- a/encode_test.go
+++ b/encode_test.go
@@ -287,7 +287,7 @@ var marshalTests = []struct {
 
 	// Ordered maps.
 	{
-		&yaml.MapSlice{{"b", 2}, {"a", 1}, {"d", 4}, {"c", 3}, {"sub", yaml.MapSlice{{"e", 5}}}},
+		&yaml.MapSlice{{"b", 2, 0, 0}, {"a", 1, 0, 0}, {"d", 4, 0, 0}, {"c", 3, 0, 0}, {"sub", yaml.MapSlice{{"e", 5, 0, 0}}, 0, 0}},
 		"b: 2\na: 1\nd: 4\nc: 3\nsub:\n  e: 5\n",
 	},
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	yaml "."
 	"net"
 	"os"
 )

--- a/yaml.go
+++ b/yaml.go
@@ -21,6 +21,7 @@ type MapSlice []MapItem
 // MapItem is an item in a MapSlice.
 type MapItem struct {
 	Key, Value interface{}
+	Line, Col int
 }
 
 // The Unmarshaler interface may be implemented by types to customize their

--- a/yaml.go
+++ b/yaml.go
@@ -124,6 +124,12 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 //                  they were part of the outer struct. For maps, keys must
 //                  not conflict with the yaml keys of other struct fields.
 //
+//     linenum      Will cause the parser to save the line number the object
+//                  was found.
+//
+//     colnum       Will cause the parser to save the column number the object
+//                  was found.
+//
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
@@ -200,6 +206,8 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	LineNum   bool
+	ColNum    bool
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -247,6 +255,10 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.Flow = true
 				case "inline":
 					inline = true
+				case "linenum":
+					info.LineNum = true
+				case "colnum":
+					info.ColNum = true
 				default:
 					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
 				}


### PR DESCRIPTION
Here's my stab at exposing line and column numbers to the mapped structs.

The `linenum` and `colnum` flags were introduced to mark fields that
will save the line number and column number of an element.

The field should not really map to any field names on the YAML document,
since the parser won't really save it. Once line or column number is
saved to a field that carries the flags mentioned here, the parser is
done with that field.

PS.: I changed the import path for the `yaml` package on both `{encode,decode}_test.go`
files, because I needed to run the tests using my fork that has a different address. I guess
that makes everyone else's life easier too. Let me know if I should break that change into
a different patch.

Might fix #108 
