### PR TITLE
Add support for alternative timestamp formats

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -453,6 +453,11 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 			out.SetFloat(resolved)
 			good = true
 		}
+	case reflect.Struct:
+		if out.Type() == reflect.TypeOf(resolved) {
+			out.Set(reflect.ValueOf(resolved))
+			good = true
+		}
 	case reflect.Ptr:
 		if out.Type().Elem() == reflect.TypeOf(resolved) {
 			// TODO DOes this make sense? When is out a Ptr except when decoding a nil value?

--- a/decode_test.go
+++ b/decode_test.go
@@ -553,6 +553,18 @@ var unmarshalTests = []struct {
 		"a: 2015-02-24T18:19:39Z\n",
 		map[string]time.Time{"a": time.Unix(1424801979, 0)},
 	},
+	{
+		"a: 2015-01-01",
+		map[string]time.Time{"a": time.Unix(1420070400, 0)},
+	},
+	{
+		"a: !!str 2015-01-01",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		"a: \"2015-01-01\"",
+		map[string]interface{}{"a": "2015-01-01"},
+	},
 
 	// Encode empty lists as zero-length slices.
 	{

--- a/resolve.go
+++ b/resolve.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -74,7 +75,7 @@ func longTag(tag string) string {
 
 func resolvableTag(tag string) bool {
 	switch tag {
-	case "", yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG:
+	case "", yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG, yaml_TIMESTAMP_TAG:
 		return true
 	}
 	return false
@@ -122,6 +123,37 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 
 		case 'D', 'S':
 			// Int, float, or timestamp.
+
+			// Handle custom timestamp formats as described on http://yaml.org/type/timestamp.html
+			// RFC3339 is handled automatically by the time.Time implementation of the
+			// encoding.TextUnmarshaler interface but we are going to explicitly
+			// handle it here. We should only perform timestamp manipulation if
+			// there is either no quotes on the value or there is an explicit !!timestamp tag.
+
+			if shortTag(tag) == shortTag(yaml_TIMESTAMP_TAG) || tag == "" {
+				var possibleTime time.Time
+				if tryTime(time.RFC3339, in, &possibleTime) {
+					return yaml_TIMESTAMP_TAG, possibleTime
+				}
+
+				// valid iso8601
+				if tryTime("2006-01-02t15:04:05.99-07:00", in, &possibleTime) {
+					return yaml_TIMESTAMP_TAG, possibleTime
+				}
+				// space separated
+				if tryTime("2006-01-02 15:04:05.99 -7", in, &possibleTime) {
+					return yaml_TIMESTAMP_TAG, possibleTime
+				}
+				// no time zone
+				if tryTime("2006-01-02 15:04:05.99", in, &possibleTime) {
+					return yaml_TIMESTAMP_TAG, possibleTime
+				}
+				// date (00:00:00Z)
+				if tryTime("2006-01-02", in, &possibleTime) {
+					return yaml_TIMESTAMP_TAG, possibleTime
+				}
+			}
+
 			plain := strings.Replace(in, "_", "", -1)
 			intv, err := strconv.ParseInt(plain, 0, 64)
 			if err == nil {
@@ -162,8 +194,6 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					}
 				}
 			}
-			// XXX Handle timestamps here.
-
 		default:
 			panic("resolveTable item not yet handled: " + string(rune(hint)) + " (with " + in + ")")
 		}
@@ -175,6 +205,16 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 		return yaml_STR_TAG, in
 	}
 	return yaml_BINARY_TAG, encodeBase64(in)
+}
+
+func tryTime(format, value string, t *time.Time) bool {
+	attempt, err := time.Parse(format, value)
+	if err == nil {
+		*t = attempt
+		return true
+	} else {
+		return false
+	}
 }
 
 // encodeBase64 encodes s as base64 that is broken up into multiple lines


### PR DESCRIPTION
yaml.org describes several alternative formats for timestamps not
covered by the default implementation of `time.UnmarshalText()`. These
are handled explicitly in this change in resolve.go

Timestamps will only be collected if there is an explicit timestamp
tag (ie, not `!!str`) or if implicit type detection is enabled.
