### PR TITLE
preserve crlf when parsing literal blocks

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -193,6 +193,12 @@ var unmarshalTests = []struct {
 		map[string]string{"scalar": "\nliteral\n\n\ttext\n"},
 	},
 
+	// Literal block scalar with crlf
+	{
+		"scalar: | # Comment\n\r\n literal\r\n\r\n \ttext\r\n\n",
+		map[string]string{"scalar": "\r\nliteral\r\n\r\n\ttext\r\n"},
+	},
+
 	// Folded block scalar
 	{
 		"scalar: > # Comment\n\n folded\n line\n \n next\n line\n  * one\n  * two\n\n last\n line\n\n",

--- a/scannerc.go
+++ b/scannerc.go
@@ -541,17 +541,17 @@ func read_line(parser *yaml_parser_t, s []byte) []byte {
 	switch {
 	case buf[pos] == '\r' && buf[pos+1] == '\n':
 		// CR LF . LF
-		s = append(s, '\n')
+		s = append(s, '\r', '\n')
 		parser.buffer_pos += 2
 		parser.mark.index++
 		parser.unread--
 	case buf[pos] == '\r' || buf[pos] == '\n':
 		// CR|LF . LF
-		s = append(s, '\n')
+		s = append(s, buf[pos])
 		parser.buffer_pos += 1
 	case buf[pos] == '\xC2' && buf[pos+1] == '\x85':
 		// NEL . LF
-		s = append(s, '\n')
+		s = append(s, buf[pos], buf[pos+1])
 		parser.buffer_pos += 2
 	case buf[pos] == '\xE2' && buf[pos+1] == '\x80' && (buf[pos+2] == '\xA8' || buf[pos+2] == '\xA9'):
 		// LS|PS . LS|PS


### PR DESCRIPTION
While scanning the yaml stream go-yaml will drop the raw line termination and always replace it with '\n'.  In general this is fine unless you have a literal block with crlf that you need preserved:

``` yaml
stuff: |
  this is^M
  a line^M
```

Here is a sample program that shows the problem:

``` yaml
package main

import (
        "fmt"
        "gopkg.in/yaml.v2"
)

func main() {
        data := make(map[string]string)
        yaml.Unmarshal([]byte("multiline: |\n  a\r\n  b\r\n  c\r\n"), &data)
        fmt.Printf("multiline: %#v\n", data["multiline"])
}
```

``` bash
$ go run yaml-test.go
multiline: "a\nb\nc\n"
```

You can see the \r\n are replaced with \n

if we swap the `gopkg.in/yaml.v2` with my patched version `gopkg.in/coryb/yaml.v2` and run it again we will get correct output:

``` bash
$ go run yaml-test.go
multiline: "a\r\nb\r\nc\r\n"
```
