### PR TITLE
Add linenum and colnum struct field support

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -642,6 +642,28 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			inlineMap.SetMapIndex(name, value)
 		}
 	}
+
+	for _, info := range sinfo.FieldsList {
+		if info.LineNum {
+			var field reflect.Value
+			if info.Inline == nil {
+				field = out.Field(info.Num)
+			} else {
+				field = out.FieldByIndex(info.Inline)
+			}
+			field.SetInt(int64(n.line) + 1)
+		}
+		if info.ColNum {
+			var field reflect.Value
+			if info.Inline == nil {
+				field = out.Field(info.Num)
+			} else {
+				field = out.FieldByIndex(info.Inline)
+			}
+			field.SetInt(int64(n.column) + 1)
+		}
+	}
+
 	return true
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -559,6 +559,17 @@ var unmarshalTests = []struct {
 		"a: []",
 		&struct{ A []int }{[]int{}},
 	},
+
+	// Line number information from parser
+	{
+		"\n\n\n\n\n\n\n\n\n\na: one\nb: two\nc: three\n",
+		&struct {
+			A    string
+			B    string
+			Line int ",linenum"
+			Col  int ",colnum"
+		}{"one", "two", 11, 1},
+	},
 }
 
 type M map[interface{}]interface{}

--- a/yaml.go
+++ b/yaml.go
@@ -124,6 +124,10 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 //                  they were part of the outer struct. For maps, keys must
 //                  not conflict with the yaml keys of other struct fields.
 //
+//     linenum      Set value to parser line number
+//
+//     colnum       Set value to parser column number
+//
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
@@ -200,6 +204,8 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	LineNum   bool
+	ColNum    bool
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -245,6 +251,10 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.OmitEmpty = true
 				case "flow":
 					info.Flow = true
+				case "linenum":
+					info.LineNum = true
+				case "colnum":
+					info.ColNum = true
 				case "inline":
 					inline = true
 				default:


### PR DESCRIPTION
Another attempt at exposing line/column information during parsing. Similar to pull request #112 by @clarete but a little simpler. (Though it may not solve his use case).
