### PR TITLE
Support emitting comments

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -327,6 +327,15 @@ func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte
 	return true
 }
 
+// Create COMMENT.
+func yaml_comment_event_initialize(event *yaml_event_t, value []byte) bool {
+	*event = yaml_event_t{
+		typ:   yaml_COMMENT_EVENT,
+		value: value,
+	}
+	return true
+}
+
 // Create SEQUENCE-START.
 func yaml_sequence_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_sequence_style_t) bool {
 	*event = yaml_event_t{

--- a/emitterc.go
+++ b/emitterc.go
@@ -209,6 +209,29 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 
 // State dispatcher.
 func yaml_emitter_state_machine(emitter *yaml_emitter_t, event *yaml_event_t) bool {
+	// comments do not change the state, so deal with them separately
+	if event.typ == yaml_COMMENT_EVENT {
+		switch emitter.state {
+		// on the first item of a mapping, we need to indent
+		case yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE:
+			return yaml_emitter_emit_comment(emitter, event, true)
+		// place comments on their own line, and never inside
+		// a flow-style mapping or sequence
+		// TODO(directxman12): support postfix-style comments
+		case yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE:
+			fallthrough
+		case yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE:
+			fallthrough
+		case yaml_EMIT_BLOCK_MAPPING_KEY_STATE:
+			return yaml_emitter_emit_comment(emitter, event, false)
+		default:
+			// in most cases, a comment isn't valid
+			return true
+		}
+
+		return true
+	}
+
 	switch emitter.state {
 	default:
 	case yaml_EMIT_STREAM_START_STATE:
@@ -703,6 +726,26 @@ func yaml_emitter_emit_scalar(emitter *yaml_emitter_t, event *yaml_event_t) bool
 	return true
 }
 
+// Expect COMMENT.
+func yaml_emitter_emit_comment(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_increase_indent(emitter, false, false) {
+			return false
+		}
+	}
+	if !yaml_emitter_write_indent(emitter) {
+		return false
+	}
+	if !yaml_emitter_process_comment(emitter) {
+		return false
+	}
+	if first {
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+	}
+	return true
+}
+
 // Expect SEQUENCE-START.
 func yaml_emitter_emit_sequence_start(emitter *yaml_emitter_t, event *yaml_event_t) bool {
 	if !yaml_emitter_process_anchor(emitter) {
@@ -906,6 +949,11 @@ func yaml_emitter_process_scalar(emitter *yaml_emitter_t) bool {
 		return yaml_emitter_write_folded_scalar(emitter, emitter.scalar_data.value)
 	}
 	panic("unknown scalar style")
+}
+
+// Write a comment.
+func yaml_emitter_process_comment(emitter *yaml_emitter_t) bool {
+	return yaml_emitter_write_comment(emitter, emitter.scalar_data.value)
 }
 
 // Check if a %YAML directive is valid.
@@ -1157,6 +1205,10 @@ func yaml_emitter_analyze_event(emitter *yaml_emitter_t, event *yaml_event_t) bo
 		if !yaml_emitter_analyze_scalar(emitter, event.value) {
 			return false
 		}
+
+	case yaml_COMMENT_EVENT:
+		// TODO(directxman12): replace this with an analyze_xyz function
+		emitter.scalar_data.value = event.value
 
 	case yaml_SEQUENCE_START_EVENT:
 		if len(event.anchor) > 0 {
@@ -1681,5 +1733,57 @@ func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) boo
 			breaks = false
 		}
 	}
+	return true
+}
+
+func yaml_emitter_write_comment(emitter *yaml_emitter_t, value []byte) bool {
+	if !yaml_emitter_write_indicator(emitter, []byte{'#', ' '}, true, false, false) {
+		return false
+	}
+	breaks := false
+	spaces := false
+	for i := 0; i < len(value); {
+		if is_space(value, i) {
+			if !spaces && emitter.column > emitter.best_width && i > 0 && i < len(value)-1 && !is_space(value, i+1) {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				if !yaml_emitter_write_indicator(emitter, []byte{'#', ' '}, false, false, false) {
+					return false
+				}
+				i += width(value[i])
+			} else if i+1 == len(value) {
+				// never write a space at the end of the comment
+				i += width(value[i])
+			} else {
+				if !write(emitter, value, &i) {
+					return false
+				}
+			}
+			spaces = true
+		} else if is_break(value, i) {
+			i += width(value[i])
+			breaks = true
+		} else {
+			if breaks {
+				if !yaml_emitter_write_indent(emitter) {
+					return false
+				}
+				if !yaml_emitter_write_indicator(emitter, []byte{'#', ' '}, false, false, false) {
+					return false
+				}
+				emitter.indention = true
+			}
+			if !write(emitter, value, &i) {
+				return false
+			}
+			emitter.indention = false
+			spaces = false
+			breaks = false
+		}
+	}
+
+	emitter.whitespace = false
+	emitter.indention = false
 	return true
 }

--- a/yaml.go
+++ b/yaml.go
@@ -23,6 +23,17 @@ type MapItem struct {
 	Key, Value interface{}
 }
 
+// CommentedMapSlice functions identially to MapSlice, except
+// that it supports inserting comments when encoding.
+type CommentedMapSlice []CommentedMapItem
+
+// CommentedMapItem is a MapItem with a comment.  Use it with
+// CommentedMapSlice.
+type CommentedMapItem struct {
+	MapItem
+	Comment string
+}
+
 // The Unmarshaler interface may be implemented by types to customize their
 // behavior when being unmarshaled from a YAML document. The UnmarshalYAML
 // method receives a function that may be called to unmarshal the original
@@ -200,6 +211,7 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	Comment   string
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -294,6 +306,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		} else {
 			info.Key = strings.ToLower(field.Name)
 		}
+
+		info.Comment = field.Tag.Get("yamlComment")
 
 		if _, found = fieldsMap[info.Key]; found {
 			msg := "Duplicated key '" + info.Key + "' in struct " + st.String()

--- a/yamlh.go
+++ b/yamlh.go
@@ -237,6 +237,7 @@ const (
 	yaml_SEQUENCE_END_EVENT   // A SEQUENCE-END event.
 	yaml_MAPPING_START_EVENT  // A MAPPING-START event.
 	yaml_MAPPING_END_EVENT    // A MAPPING-END event.
+	yaml_COMMENT_EVENT        // A COMMENT event.
 )
 
 // The event structure.


### PR DESCRIPTION
This commit introduces support for YAML comments.  Currently,
comments are placed on the line before mapping keys (or potentially
sequence items).  Comments placed at the end of lines are not supported.

Comments may be created either by setting `yamlComment:"some comment"`
in a struct field tag, or by setting the `Comment` field of `CommentedMapItem`
(and using `CommentedMapSlice` objects instead of `MapSlice` objects).
Empty comments are skipped.  Currently, adding comments above list items
is not supported (but you can still add comments to struct fields in list items).

I introduced `CommentedMapItem` and `CommentedMapSlice` in order to not break the API
by changing the signature of `MapItem`.  If you'd rather bump the API version to have a bit cleaner
code under the hood, I can change it so that `MapItem` just has a `Comments` field instead.
