### PR TITLE
Added Encode() and Decode() to make duck-typing with json- and xml-counterparts easier 

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -9,6 +9,8 @@ package yaml
 import (
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"sync"
@@ -95,6 +97,48 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return nil
 }
 
+// YAMLDecoder implements the Decode() method which makes it usable in
+// conjunction with json- and xml-Decoders.
+type YAMLDecoder struct {
+	r io.Reader
+}
+
+func NewDecoder(r io.Reader) *YAMLDecoder {
+	return &YAMLDecoder{r: r}
+}
+
+// Decode has the same signature as its json- and xml-counterparts.  This
+// allows it to ducktype with those Decoders, pass them around as arguments,
+// use them in struct-members.  A trivial example would be:
+//
+//		type Decoder interface {
+//		 Decoder(interface{}) error
+//		}
+//		...
+//		var dec Decoder
+//		...
+//
+//		switch input_format {
+//		case "xml":
+//			dec = xml.NewDecoder(input)
+//		case "json":
+//		  dec = json.NewDecoder(input)
+//		case "yaml":
+//		  dec = yaml.NewDecoder(input)
+//		}
+//
+//		...
+//
+//		err := dec.Decode(&target)
+//
+func (dec *YAMLDecoder) Decode(v interface{}) error {
+	buf, err := ioutil.ReadAll(dec.r)
+	if err != nil {
+		return err
+	}
+	return Unmarshal(buf, v)
+}
+
 // Marshal serializes the value provided into a YAML document. The structure
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.
@@ -143,6 +187,49 @@ func Marshal(in interface{}) (out []byte, err error) {
 	e.finish()
 	out = e.out
 	return
+}
+
+// YAMLEncoder implements the Encode() method which makes it usable in
+// conjunction with json- and xml-Encoders.
+type YAMLEncoder struct {
+	w io.Writer
+}
+
+func NewEncoder(w io.Writer) *YAMLEncoder {
+	return &YAMLEncoder{w: w}
+}
+
+// Encode has the same signature as its json- and xml-counterparts.  This
+// allows it to ducktype with those Encoders, pass them around as arguments,
+// use them in struct-members.  A trivial example would be:
+//
+//		type Encoder interface {
+//			Encode(interface{}) error
+//		}
+//
+//		type Data struct {
+//			Foo string
+//			Bar int
+//		}
+//
+//		func main() {
+//			buf := &bytes.Buffer{}
+//
+//			for i, enc := range []Encoder{
+//					yaml.NewEncoder(buf),
+//					json.NewEncoder(buf),
+//					xml.NewEncoder(buf),
+//		  } {
+//				buf.Reset()
+//				err := enc.Encode(Data{Foo: "Foo String", Bar: 42})
+//        ...
+func (enc *YAMLEncoder) Encode(v interface{}) error {
+	buf, err := Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = enc.w.Write(buf)
+	return err
 }
 
 func handleErr(err *error) {

--- a/yaml.go
+++ b/yaml.go
@@ -111,25 +111,22 @@ func NewDecoder(r io.Reader) *YAMLDecoder {
 // allows it to ducktype with those Decoders, pass them around as arguments,
 // use them in struct-members.  A trivial example would be:
 //
-//		type Decoder interface {
-//		 Decoder(interface{}) error
-//		}
-//		...
-//		var dec Decoder
-//		...
+//	type Decoder interface {
+//	 Decoder(interface{}) error
+//	}
 //
-//		switch input_format {
-//		case "xml":
-//			dec = xml.NewDecoder(input)
-//		case "json":
-//		  dec = json.NewDecoder(input)
-//		case "yaml":
-//		  dec = yaml.NewDecoder(input)
-//		}
+//	var dec Decoder
 //
-//		...
+//	switch input_format {
+//	case "xml":
+//		dec = xml.NewDecoder(input)
+//	case "json":
+//	  dec = json.NewDecoder(input)
+//	case "yaml":
+//	  dec = yaml.NewDecoder(input)
+//	}
 //
-//		err := dec.Decode(&target)
+//	err := dec.Decode(&target)
 //
 func (dec *YAMLDecoder) Decode(v interface{}) error {
 	buf, err := ioutil.ReadAll(dec.r)
@@ -203,26 +200,26 @@ func NewEncoder(w io.Writer) *YAMLEncoder {
 // allows it to ducktype with those Encoders, pass them around as arguments,
 // use them in struct-members.  A trivial example would be:
 //
-//		type Encoder interface {
-//			Encode(interface{}) error
-//		}
+//	type Encoder interface {
+//		Encode(interface{}) error
+//	}
 //
-//		type Data struct {
-//			Foo string
-//			Bar int
-//		}
+//	type Data struct {
+//		Foo string
+//		Bar int
+//	}
 //
-//		func main() {
-//			buf := &bytes.Buffer{}
+//	func main() {
+//		buf := &bytes.Buffer{}
 //
-//			for i, enc := range []Encoder{
-//					yaml.NewEncoder(buf),
-//					json.NewEncoder(buf),
-//					xml.NewEncoder(buf),
-//		  } {
-//				buf.Reset()
-//				err := enc.Encode(Data{Foo: "Foo String", Bar: 42})
-//        ...
+//		for i, enc := range []Encoder{
+//				yaml.NewEncoder(buf),
+//				json.NewEncoder(buf),
+//				xml.NewEncoder(buf),
+//	  } {
+//			buf.Reset()
+//			err := enc.Encode(Data{Foo: "Foo String", Bar: 42})
+//      ...
 func (enc *YAMLEncoder) Encode(v interface{}) error {
 	buf, err := Marshal(v)
 	if err != nil {


### PR DESCRIPTION
Hi,

In my current project I needed to be able to handle Encoders and Decoders for any of the formats xml, json and yaml more easily and ended up declaring a corresponding interface type and implementing Encode() and Decode() in the yaml-package.  That way, I can pass En-/Decoders around.  See http://play.golang.org/p/JGD2dhk7ZU for a trivial example.

Maybe you'll find it usefull.

Cheers,
  Özgür
