### PR TITLE
Fix parsing of non-specific node tags (issue #75)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -403,6 +403,12 @@ var unmarshalTests = []struct {
 	}, {
 		"%TAG !y! tag:yaml.org,2002:\n---\nv: !y!int '1'",
 		map[string]interface{}{"v": 1},
+	}, {
+		"v: ! 12",
+		map[string]interface{}{"v": "12"},
+	}, {
+		"seq: ! [A, B]",
+		map[string]interface{}{"seq": []interface{}{"A", "B"}},
 	},
 
 	// Anchors and aliases.

--- a/scannerc.go
+++ b/scannerc.go
@@ -2002,12 +2002,6 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 		}
 	}
 
-	// Check if the tag is non-empty.
-	if len(s) == 0 {
-		yaml_parser_set_scanner_tag_error(parser, directive,
-			start_mark, "did not find expected tag URI")
-		return false
-	}
 	*uri = s
 	return true
 }


### PR DESCRIPTION
Non-specific tag disables tag resolution, forcing the node to be
interpreted as `tag:yaml.org,2002:seq`, `tag:yaml.org,2002:map`, or
`tag:yaml.org,2002:str`

This fix pevents `yaml_parser_scan_tag_uri` from raising an error if
`suffix` is empty. This case is handled by function `yam_parser_scan_tag`:
https://github.com/go-yaml/yaml/blob/v2/scannerc.go#L1882
so this behaviour is expected.
