### PR TITLE
Fix typo: "uknown" → “unknown"

### DIFF
--- a/scannerc.go
+++ b/scannerc.go
@@ -1546,7 +1546,7 @@ func yaml_parser_scan_directive(parser *yaml_parser_t, token *yaml_token_t) bool
 		// Unknown directive.
 	} else {
 		yaml_parser_set_scanner_error(parser, "while scanning a directive",
-			start_mark, "found uknown directive name")
+			start_mark, "found unknown directive name")
 		return false
 	}
 


### PR DESCRIPTION
Discovered by Lintian checks on Debian:

```
I: hugo: spelling-error-in-binary usr/bin/hugo uknown unknown
```

Thanks!
