### PR TITLE
make compatible with Go 1.6

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -222,7 +222,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 	inlineMap := -1
 	for i := 0; i != n; i++ {
 		field := st.Field(i)
-		if field.PkgPath != "" {
+		if field.PkgPath != "" && !field.Anonymous {
 			continue // Private field
 		}
 


### PR DESCRIPTION
As documented at http://tip.golang.org/doc/go1.6#reflect, the rules around
embedded unexported struct types containing exported fields are changing in Go
1.6. The same release notes explain how to change existing code, so do that.
