### PR TITLE
Add public UnmarshalNode API

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -11,21 +11,21 @@ import (
 )
 
 const (
-	documentNode = 1 << iota
-	mappingNode
-	sequenceNode
-	scalarNode
-	aliasNode
+	DocumentNode = 1 << iota
+	MappingNode
+	SequenceNode
+	ScalarNode
+	AliasNode
 )
 
-type node struct {
+type Node struct {
 	kind         int
 	line, column int
 	tag          string
 	value        string
 	implicit     bool
-	children     []*node
-	anchors      map[string]*node
+	children     []*Node
+	anchors      map[string]*Node
 }
 
 // ----------------------------------------------------------------------------
@@ -34,7 +34,7 @@ type node struct {
 type parser struct {
 	parser yaml_parser_t
 	event  yaml_event_t
-	doc    *node
+	doc    *Node
 }
 
 func newParser(b []byte) *parser {
@@ -96,13 +96,13 @@ func (p *parser) fail() {
 	failf("%s%s", where, msg)
 }
 
-func (p *parser) anchor(n *node, anchor []byte) {
+func (p *parser) anchor(n *Node, anchor []byte) {
 	if anchor != nil {
 		p.doc.anchors[string(anchor)] = n
 	}
 }
 
-func (p *parser) parse() *node {
+func (p *parser) parse() *Node {
 	switch p.event.typ {
 	case yaml_SCALAR_EVENT:
 		return p.scalar()
@@ -123,17 +123,17 @@ func (p *parser) parse() *node {
 	panic("unreachable")
 }
 
-func (p *parser) node(kind int) *node {
-	return &node{
+func (p *parser) node(kind int) *Node {
+	return &Node{
 		kind:   kind,
 		line:   p.event.start_mark.line,
 		column: p.event.start_mark.column,
 	}
 }
 
-func (p *parser) document() *node {
-	n := p.node(documentNode)
-	n.anchors = make(map[string]*node)
+func (p *parser) document() *Node {
+	n := p.node(DocumentNode)
+	n.anchors = make(map[string]*Node)
 	p.doc = n
 	p.skip()
 	n.children = append(n.children, p.parse())
@@ -144,15 +144,15 @@ func (p *parser) document() *node {
 	return n
 }
 
-func (p *parser) alias() *node {
-	n := p.node(aliasNode)
+func (p *parser) alias() *Node {
+	n := p.node(AliasNode)
 	n.value = string(p.event.anchor)
 	p.skip()
 	return n
 }
 
-func (p *parser) scalar() *node {
-	n := p.node(scalarNode)
+func (p *parser) scalar() *Node {
+	n := p.node(ScalarNode)
 	n.value = string(p.event.value)
 	n.tag = string(p.event.tag)
 	n.implicit = p.event.implicit
@@ -161,8 +161,8 @@ func (p *parser) scalar() *node {
 	return n
 }
 
-func (p *parser) sequence() *node {
-	n := p.node(sequenceNode)
+func (p *parser) sequence() *Node {
+	n := p.node(SequenceNode)
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	for p.event.typ != yaml_SEQUENCE_END_EVENT {
@@ -172,8 +172,8 @@ func (p *parser) sequence() *node {
 	return n
 }
 
-func (p *parser) mapping() *node {
-	n := p.node(mappingNode)
+func (p *parser) mapping() *Node {
+	n := p.node(MappingNode)
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	for p.event.typ != yaml_MAPPING_END_EVENT {
@@ -187,7 +187,7 @@ func (p *parser) mapping() *node {
 // Decoder, unmarshals a node into a provided value.
 
 type decoder struct {
-	doc     *node
+	doc     *Node
 	aliases map[string]bool
 	mapType reflect.Type
 	terrors []string
@@ -206,7 +206,7 @@ func newDecoder() *decoder {
 	return d
 }
 
-func (d *decoder) terror(n *node, tag string, out reflect.Value) {
+func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 	if n.tag != "" {
 		tag = n.tag
 	}
@@ -221,7 +221,7 @@ func (d *decoder) terror(n *node, tag string, out reflect.Value) {
 	d.terrors = append(d.terrors, fmt.Sprintf("line %d: cannot unmarshal %s%s into %s", n.line+1, shortTag(tag), value, out.Type()))
 }
 
-func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
+func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 	terrlen := len(d.terrors)
 	err := u.UnmarshalYAML(func(v interface{}) (err error) {
 		defer handleErr(&err)
@@ -250,8 +250,8 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 // its types unmarshalled appropriately.
 //
 // If n holds a null value, prepare returns before doing anything.
-func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "") {
+func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
+	if n.tag == yaml_NULL_TAG || n.kind == ScalarNode && n.tag == "" && (n.value == "null" || n.value == "") {
 		return out, false, false
 	}
 	again := true
@@ -274,11 +274,11 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 	return out, false, false
 }
 
-func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
+func (d *decoder) unmarshal(n *Node, out reflect.Value) (good bool) {
 	switch n.kind {
-	case documentNode:
+	case DocumentNode:
 		return d.document(n, out)
-	case aliasNode:
+	case AliasNode:
 		return d.alias(n, out)
 	}
 	out, unmarshaled, good := d.prepare(n, out)
@@ -286,11 +286,11 @@ func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 		return good
 	}
 	switch n.kind {
-	case scalarNode:
+	case ScalarNode:
 		good = d.scalar(n, out)
-	case mappingNode:
+	case MappingNode:
 		good = d.mapping(n, out)
-	case sequenceNode:
+	case SequenceNode:
 		good = d.sequence(n, out)
 	default:
 		panic("internal error: unknown node kind: " + strconv.Itoa(n.kind))
@@ -298,7 +298,7 @@ func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 	return good
 }
 
-func (d *decoder) document(n *node, out reflect.Value) (good bool) {
+func (d *decoder) document(n *Node, out reflect.Value) (good bool) {
 	if len(n.children) == 1 {
 		d.doc = n
 		d.unmarshal(n.children[0], out)
@@ -307,7 +307,7 @@ func (d *decoder) document(n *node, out reflect.Value) (good bool) {
 	return false
 }
 
-func (d *decoder) alias(n *node, out reflect.Value) (good bool) {
+func (d *decoder) alias(n *Node, out reflect.Value) (good bool) {
 	an, ok := d.doc.anchors[n.value]
 	if !ok {
 		failf("unknown anchor '%s' referenced", n.value)
@@ -329,7 +329,7 @@ func resetMap(out reflect.Value) {
 	}
 }
 
-func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
+func (d *decoder) scalar(n *Node, out reflect.Value) (good bool) {
 	var tag string
 	var resolved interface{}
 	if n.tag == "" && !n.implicit {
@@ -475,7 +475,7 @@ func settableValueOf(i interface{}) reflect.Value {
 	return sv
 }
 
-func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
+func (d *decoder) sequence(n *Node, out reflect.Value) (good bool) {
 	l := len(n.children)
 
 	var iface reflect.Value
@@ -507,7 +507,7 @@ func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
 	return true
 }
 
-func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
+func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 	switch out.Kind() {
 	case reflect.Struct:
 		return d.mappingStruct(n, out)
@@ -569,7 +569,7 @@ func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 	return true
 }
 
-func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
+func (d *decoder) mappingSlice(n *Node, out reflect.Value) (good bool) {
 	outt := out.Type()
 	if outt.Elem() != mapItemType {
 		d.terror(n, yaml_MAP_TAG, out)
@@ -600,7 +600,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 	return true
 }
 
-func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
+func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 	sinfo, err := getStructInfo(out.Type())
 	if err != nil {
 		panic(err)
@@ -649,26 +649,26 @@ func failWantMap() {
 	failf("map merge requires map or sequence of maps as the value")
 }
 
-func (d *decoder) merge(n *node, out reflect.Value) {
+func (d *decoder) merge(n *Node, out reflect.Value) {
 	switch n.kind {
-	case mappingNode:
+	case MappingNode:
 		d.unmarshal(n, out)
-	case aliasNode:
+	case AliasNode:
 		an, ok := d.doc.anchors[n.value]
-		if ok && an.kind != mappingNode {
+		if ok && an.kind != MappingNode {
 			failWantMap()
 		}
 		d.unmarshal(n, out)
-	case sequenceNode:
+	case SequenceNode:
 		// Step backwards as earlier nodes take precedence.
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
-			if ni.kind == aliasNode {
+			if ni.kind == AliasNode {
 				an, ok := d.doc.anchors[ni.value]
-				if ok && an.kind != mappingNode {
+				if ok && an.kind != MappingNode {
 					failWantMap()
 				}
-			} else if ni.kind != mappingNode {
+			} else if ni.kind != MappingNode {
 				failWantMap()
 			}
 			d.unmarshal(ni, out)
@@ -678,6 +678,6 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 	}
 }
 
-func isMerge(n *node) bool {
-	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
+func isMerge(n *Node) bool {
+	return n.kind == ScalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
 }

--- a/yaml.go
+++ b/yaml.go
@@ -95,6 +95,20 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return nil
 }
 
+// UnmarshalNode decodes the first document found within the in byte slice
+// and assigns decoded values into Node representation.
+func UnmarshalNode(in []byte) (node *Node, err error) {
+	defer handleErr(&err)
+	d := newDecoder()
+	p := newParser(in)
+	defer p.destroy()
+	node = p.parse()
+	if len(d.terrors) > 0 {
+		err = &TypeError{d.terrors}
+	}
+	return
+}
+
 // Marshal serializes the value provided into a YAML document. The structure
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.


### PR DESCRIPTION
This new function returns Node struct for usecase which needs
line position of YAML objects for better error message on semantic error
in appliaction use.
This PR also makes Node sturct and related constant public.
