### PR TITLE
Support for go-like field name handling (100% v2 backwards compat)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -187,10 +187,11 @@ func (p *parser) mapping() *node {
 // Decoder, unmarshals a node into a provided value.
 
 type decoder struct {
-	doc     *node
-	aliases map[string]bool
-	mapType reflect.Type
-	terrors []string
+	doc       *node
+	aliases   map[string]bool
+	mapType   reflect.Type
+	terrors   []string
+	yamlCodec *YAMLCodec
 }
 
 var (
@@ -200,8 +201,8 @@ var (
 	ifaceType      = defaultMapType.Elem()
 )
 
-func newDecoder() *decoder {
-	d := &decoder{mapType: defaultMapType}
+func newDecoder(y *YAMLCodec) *decoder {
+	d := &decoder{mapType: defaultMapType, yamlCodec: y}
 	d.aliases = make(map[string]bool)
 	return d
 }
@@ -601,7 +602,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 }
 
 func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
-	sinfo, err := getStructInfo(out.Type())
+	sinfo, err := d.yamlCodec.getStructInfo(out.Type())
 	if err != nil {
 		panic(err)
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -966,9 +966,9 @@ func (s *S) TestUnmarshalUppercaseFieldNamesNormal(c *C) {
 
 }
 
-func (s *S) TestUnmarshalUppercaseFieldNamesWithoutLowercase(c *C) {
+func (s *S) TestUnmarshalWithOptions_UppercaseFieldNamesWithoutLowercase(c *C) {
 	v := struct{ AbcDef string }{}
-	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v, yaml.OPT_NOLOWERCASE)
+	yaml.UnmarshalWithOptions([]byte("---\nAbcDef: hello\n"), &v, yaml.OPT_NOLOWERCASE)
 	c.Assert(v.AbcDef, Equals, "hello")
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -960,37 +960,17 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 }
 
 func (s *S) TestUnmarshalUppercaseFieldNamesNormal(c *C) {
-	v := struct {
-		AbcDef string
-	}{}
+	v := struct{ AbcDef string }{}
 	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v)
 	c.Assert(v.AbcDef, Equals, "")
 
 }
 
-type V struct {
-	AbcDef string
-}
-
 func (s *S) TestUnmarshalUppercaseFieldNamesWithoutLowercase(c *C) {
-	v := V{}
+	v := struct{ AbcDef string }{}
 	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v, yaml.OPT_NOLOWERCASE)
 	c.Assert(v.AbcDef, Equals, "hello")
 }
-
-type TestType struct {
-	AbcDef TestTypeNested
-}
-
-type TestTypeNested struct {
-	XyZ string
-}
-
-//func (s *S) TestUnmarshalNestedUppercaseFieldNamesWithoutLowercase(c *C) {
-//	v := TestType{AbcDef: TestTypeNested{"hello"}}
-//	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v, yaml.OptionNoLowercase)
-//	c.Assert(v.AbcDef, Equals, "hello")
-//}
 
 //var data []byte
 //func init() {

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,13 +2,14 @@ package yaml_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123
@@ -957,6 +958,39 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 	yaml.Unmarshal([]byte("a: [2]"), &v)
 	c.Assert(v.A, DeepEquals, []int{2})
 }
+
+func (s *S) TestUnmarshalUppercaseFieldNamesNormal(c *C) {
+	v := struct {
+		AbcDef string
+	}{}
+	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v)
+	c.Assert(v.AbcDef, Equals, "")
+
+}
+
+type V struct {
+	AbcDef string
+}
+
+func (s *S) TestUnmarshalUppercaseFieldNamesWithoutLowercase(c *C) {
+	v := V{}
+	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v, yaml.OPT_NOLOWERCASE)
+	c.Assert(v.AbcDef, Equals, "hello")
+}
+
+type TestType struct {
+	AbcDef TestTypeNested
+}
+
+type TestTypeNested struct {
+	XyZ string
+}
+
+//func (s *S) TestUnmarshalNestedUppercaseFieldNamesWithoutLowercase(c *C) {
+//	v := TestType{AbcDef: TestTypeNested{"hello"}}
+//	yaml.Unmarshal([]byte("---\nAbcDef: hello\n"), &v, yaml.OptionNoLowercase)
+//	c.Assert(v.AbcDef, Equals, "hello")
+//}
 
 //var data []byte
 //func init() {

--- a/encode.go
+++ b/encode.go
@@ -12,14 +12,15 @@ import (
 )
 
 type encoder struct {
-	emitter yaml_emitter_t
-	event   yaml_event_t
-	out     []byte
-	flow    bool
+	emitter   yaml_emitter_t
+	event     yaml_event_t
+	out       []byte
+	flow      bool
+	yamlCodec *YAMLCodec
 }
 
-func newEncoder() (e *encoder) {
-	e = &encoder{}
+func newEncoder(y *YAMLCodec) (e *encoder) {
+	e = &encoder{yamlCodec: y}
 	e.must(yaml_emitter_initialize(&e.emitter))
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -146,7 +147,7 @@ func (e *encoder) itemsv(tag string, in reflect.Value) {
 }
 
 func (e *encoder) structv(tag string, in reflect.Value) {
-	sinfo, err := getStructInfo(in.Type())
+	sinfo, err := e.yamlCodec.getStructInfo(in.Type())
 	if err != nil {
 		panic(err)
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -507,9 +507,9 @@ func (s *S) TestMarshalUppercaseFieldNamesNormal(c *C) {
 	c.Assert(string(y), Equals, "abcdef: hello\n")
 }
 
-func (s *S) TestMarshalUppercaseFieldNamesWithoutLowercase(c *C) {
+func (s *S) TestMarshalWithOptiosn_UppercaseFieldNamesWithoutLowercase(c *C) {
 	v := struct{ AbcDef string }{"hello"}
-	y, err := yaml.Marshal(v, yaml.OPT_NOLOWERCASE)
+	y, err := yaml.MarshalWithOptions(v, yaml.OPT_NOLOWERCASE)
 	c.Assert(err, IsNil)
 	c.Assert(string(y), Equals, "AbcDef: hello\n")
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -501,7 +501,7 @@ func (s *S) TestSortedOutput(c *C) {
 }
 
 func (s *S) TestMarshalUppercaseFieldNamesNormal(c *C) {
-	v := V{"hello"}
+	v := struct{ AbcDef string }{"hello"}
 	y, err := yaml.Marshal(v)
 	c.Assert(err, IsNil)
 	c.Assert(string(y), Equals, "abcdef: hello\n")

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,14 +3,14 @@ package yaml_test
 import (
 	"fmt"
 	"math"
+	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
-	"net"
-	"os"
 )
 
 var marshalIntTest = 123
@@ -498,4 +498,18 @@ func (s *S) TestSortedOutput(c *C) {
 		}
 		last = index
 	}
+}
+
+func (s *S) TestMarshalUppercaseFieldNamesNormal(c *C) {
+	v := V{"hello"}
+	y, err := yaml.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(y), Equals, "abcdef: hello\n")
+}
+
+func (s *S) TestMarshalUppercaseFieldNamesWithoutLowercase(c *C) {
+	v := struct{ AbcDef string }{"hello"}
+	y, err := yaml.Marshal(v, yaml.OPT_NOLOWERCASE)
+	c.Assert(err, IsNil)
+	c.Assert(string(y), Equals, "AbcDef: hello\n")
 }

--- a/yaml.go
+++ b/yaml.go
@@ -14,6 +14,27 @@ import (
 	"sync"
 )
 
+// YAMLCodec implements Marshal and Unmarshal.
+type YAMLCodec struct {
+	opt           Option
+	structMap     map[reflect.Type]*structInfo
+	fieldMapMutex sync.RWMutex
+}
+
+// NewYAMLCodec creates a new *YAMLCodec configured with the provided options
+// (optional).
+func NewYAMLCodec(options ...Option) *YAMLCodec {
+	option := OPT_NONE
+	for _, o := range options {
+		option |= o
+	}
+	return &YAMLCodec{
+		option,
+		make(map[reflect.Type]*structInfo),
+		sync.RWMutex{},
+	}
+}
+
 // MapSlice encodes and decodes as a YAML map.
 // The order of keys is preserved when encoding and decoding.
 type MapSlice []MapItem
@@ -58,11 +79,12 @@ type Marshaler interface {
 //
 // Struct fields are only unmarshalled if they are exported (have an
 // upper case first letter), and are unmarshalled using the field name
-// lowercased as the default key. Custom keys may be defined via the
-// "yaml" name in the field tag: the content preceding the first comma
-// is used as the key, and the following comma-separated options are
-// used to tweak the marshalling process (see Marshal).
-// Conflicting names result in a runtime error.
+// lowercased as the default key, unless provided options override this.
+//
+// Custom keys may be defined via the "yaml" name in the field
+// tag: the content preceding the first comma is used as the key, and the
+// following comma-separated options are used to tweak the marshalling
+// process (see Marshal). Conflicting names result in a runtime error.
 //
 // For example:
 //
@@ -76,9 +98,9 @@ type Marshaler interface {
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
 //
-func Unmarshal(in []byte, out interface{}) (err error) {
+func (y *YAMLCodec) Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
-	d := newDecoder()
+	d := newDecoder(y)
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()
@@ -95,16 +117,30 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return nil
 }
 
+// Shorthand for NewYAMLCodec(options...).Unmarshal(in, out)
+func Unmarshal(in []byte, out interface{}, opts ...Option) (err error) {
+	return NewYAMLCodec(opts...).Unmarshal(in, out)
+}
+
+type Option int
+
+const (
+	OPT_NONE Option = 1 << iota
+	OPT_NOLOWERCASE
+)
+
 // Marshal serializes the value provided into a YAML document. The structure
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.
 //
 // Struct fields are only unmarshalled if they are exported (have an upper case
 // first letter), and are unmarshalled using the field name lowercased as the
-// default key. Custom keys may be defined via the "yaml" name in the field
-// tag: the content preceding the first comma is used as the key, and the
-// following comma-separated options are used to tweak the marshalling process.
-// Conflicting names result in a runtime error.
+// default key, unless the provided options override this behaviour.
+//
+// Custom keys may be defined via the
+// "yaml" name in the field tag: the content preceding the first comma is used as
+// the key, and the following comma-separated options are used to tweak the
+// marshalling process. Conflicting names result in a runtime error.
 //
 // The field tag format accepted is:
 //
@@ -135,14 +171,19 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 //     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
 //     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 //
-func Marshal(in interface{}) (out []byte, err error) {
+func (y *YAMLCodec) Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
-	e := newEncoder()
+	e := newEncoder(y)
 	defer e.destroy()
 	e.marshal("", reflect.ValueOf(in))
 	e.finish()
 	out = e.out
 	return
+}
+
+// Shorthand for NewYAMLCodec(options...).Marshal(in)
+func Marshal(in interface{}, options ...Option) (out []byte, err error) {
+	return NewYAMLCodec(options...).Marshal(in)
 }
 
 func handleErr(err *error) {
@@ -205,13 +246,10 @@ type fieldInfo struct {
 	Inline []int
 }
 
-var structMap = make(map[reflect.Type]*structInfo)
-var fieldMapMutex sync.RWMutex
-
-func getStructInfo(st reflect.Type) (*structInfo, error) {
-	fieldMapMutex.RLock()
-	sinfo, found := structMap[st]
-	fieldMapMutex.RUnlock()
+func (y *YAMLCodec) getStructInfo(st reflect.Type) (*structInfo, error) {
+	y.fieldMapMutex.RLock()
+	sinfo, found := y.structMap[st]
+	y.fieldMapMutex.RUnlock()
 	if found {
 		return sinfo, nil
 	}
@@ -265,7 +303,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				}
 				inlineMap = info.Num
 			case reflect.Struct:
-				sinfo, err := getStructInfo(field.Type)
+				sinfo, err := y.getStructInfo(field.Type)
 				if err != nil {
 					return nil, err
 				}
@@ -291,6 +329,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 
 		if tag != "" {
 			info.Key = tag
+		} else if y.opt&OPT_NOLOWERCASE != 0 {
+			info.Key = field.Name
 		} else {
 			info.Key = strings.ToLower(field.Name)
 		}
@@ -306,9 +346,9 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 
 	sinfo = &structInfo{fieldsMap, fieldsList, inlineMap}
 
-	fieldMapMutex.Lock()
-	structMap[st] = sinfo
-	fieldMapMutex.Unlock()
+	y.fieldMapMutex.Lock()
+	y.structMap[st] = sinfo
+	y.fieldMapMutex.Unlock()
 	return sinfo, nil
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -21,6 +21,8 @@ type YAMLCodec struct {
 	fieldMapMutex sync.RWMutex
 }
 
+var DefaultCodec = NewYAMLCodec()
+
 // NewYAMLCodec creates a new *YAMLCodec configured with the provided options
 // (optional).
 func NewYAMLCodec(options ...Option) *YAMLCodec {
@@ -117,9 +119,14 @@ func (y *YAMLCodec) Unmarshal(in []byte, out interface{}) (err error) {
 	return nil
 }
 
-// Shorthand for NewYAMLCodec(options...).Unmarshal(in, out)
-func Unmarshal(in []byte, out interface{}, opts ...Option) (err error) {
+// UnmarshalWithOptions is shorthand for NewCodec(options...).Unmarshal(in, out)
+func UnmarshalWithOptions(in []byte, out interface{}, opts ...Option) (err error) {
 	return NewYAMLCodec(opts...).Unmarshal(in, out)
+}
+
+// Unmarshal is shorthand for DefaultCodec.Unmarshal(in, out)
+func Unmarshal(in []byte, out interface{}) (err error) {
+	return DefaultCodec.Unmarshal(in, out)
 }
 
 type Option int
@@ -181,9 +188,14 @@ func (y *YAMLCodec) Marshal(in interface{}) (out []byte, err error) {
 	return
 }
 
-// Shorthand for NewYAMLCodec(options...).Marshal(in)
-func Marshal(in interface{}, options ...Option) (out []byte, err error) {
+// MarshalWithOptions is shorthand for NewCodec(options...).Marshal(in)
+func MarshalWithOptions(in interface{}, options ...Option) (out []byte, err error) {
 	return NewYAMLCodec(options...).Marshal(in)
+}
+
+// Marshal is shorthand for DefaultCodec.Marshal()
+func Marshal(in interface{}) (out []byte, err error) {
+	return DefaultCodec.Marshal(in)
 }
 
 func handleErr(err *error) {


### PR DESCRIPTION
This is a follow on from #149, adding 2 extra methods `MarshalWithOptions` and `UnmarshalWithOptions` (both accepting options to control field name handling) and leaving `Marshal` and `Unmarshal` with the same signature as v2 has currently.
