### PR TITLE
Remove unreachable code

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -120,7 +120,6 @@ func (p *parser) parse() *node {
 	default:
 		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
 	}
-	panic("unreachable")
 }
 
 func (p *parser) node(kind int) *node {

--- a/emitterc.go
+++ b/emitterc.go
@@ -666,7 +666,6 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 		return yaml_emitter_set_emitter_error(emitter,
 			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
 	}
-	return false
 }
 
 // Expect ALIAS.

--- a/parserc.go
+++ b/parserc.go
@@ -166,7 +166,6 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 	default:
 		panic("invalid parser state")
 	}
-	return false
 }
 
 // Parse the production:


### PR DESCRIPTION
Removes three cases of unreachable code found by `go vet`. There are still `go vet` warnings coming from some of the test files, but those are less important to fix. Most vendoring tools do not fetch test files. Anybody using `gvt`, `govendor`, etc. will be able to run `go vet ./...` on their own projects and not see any warnings from `go-yaml`.
