### PR TITLE
Add package option for mimicking encoding/json field name case handling

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -145,6 +145,14 @@ func Marshal(in interface{}) (out []byte, err error) {
 	return
 }
 
+// Individual apps can use SetPreserveCase(true) to mimic the encoding/json
+// behavior that preserves the case of struct fields.
+var preserveFieldCase bool = false
+
+func SetPreserveFieldCase(b bool) {
+	preserveFieldCase = b
+}
+
 func handleErr(err *error) {
 	if v := recover(); v != nil {
 		if e, ok := v.(yamlError); ok {
@@ -291,6 +299,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 
 		if tag != "" {
 			info.Key = tag
+		} else if preserveFieldCase {
+			info.Key = field.Name
 		} else {
 			info.Key = strings.ToLower(field.Name)
 		}

--- a/yaml.go
+++ b/yaml.go
@@ -149,6 +149,13 @@ func Marshal(in interface{}) (out []byte, err error) {
 // behavior that preserves the case of struct fields.
 var preserveFieldCase bool = false
 
+// SetPreserveFieldCase allows consumers of the library to modify the behavior
+// of key name matching/generation to match encoding/json.
+// SetPreserveFieldCase(true) keeps the original case of field names (or uses
+// the provided yaml: struct tag), where stock behavior is to use ToLower()
+// on struct field names.
+// This function is not thread-safe, and should be called once from an
+// init() function to set behavior for the application.
 func SetPreserveFieldCase(b bool) {
 	preserveFieldCase = b
 }


### PR DESCRIPTION
I read the other pull request for similar functionality, but didn't want to implement as part of a Decoder/Encoder because it wouldn't give the behavior I wanted when using standard Marshal/Unmarshal. This non-breaking change adds a package option to preserve the case of
field names when marshaling/unmarshaling.

If this approach is acceptable, I'll be glad to get a launchpad ID and fill out the form, but didn't want to bother without getting feedback first. Thanks!
