### PR TITLE
new license in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package API for yaml v2 will remain stable as described in [gopkg.in](https:
 License
 -------
 
-The yaml package is licensed under the LGPL with an exception that allows it to be linked statically. Please see the LICENSE file for details.
+The yaml package is licensed under the Apache License 2.0. Please see the LICENSE file for details.
 
 
 Example


### PR DESCRIPTION
Hi,

Recently go-yaml updated license to Apache v2.

Unfortunately, that was not reflected in the README file.
