### PR TITLE
Fix unstable map ordering for specific keys with numbers

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"time"
 
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"net"
 	"os"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var marshalIntTest = 123
@@ -456,7 +457,8 @@ func (s *S) TestSortedOutput(c *C) {
 		"2",
 		"a!10",
 		"a/2",
-		"a/10",
+		"a/11",
+		"a/100",
 		"a~10",
 		"ab/1",
 		"b/1",
@@ -471,31 +473,41 @@ func (s *S) TestSortedOutput(c *C) {
 		"c2.10",
 		"c10.2",
 		"d1",
+		"d7",
+		"d7abc",
+		"d007",
+		"d007abc",
 		"d12",
 		"d12a",
 	}
+
 	m := make(map[interface{}]int)
 	for _, k := range order {
 		m[k] = 1
 	}
-	data, err := yaml.Marshal(m)
-	c.Assert(err, IsNil)
-	out := "\n" + string(data)
-	last := 0
-	for i, k := range order {
-		repr := fmt.Sprint(k)
-		if s, ok := k.(string); ok {
-			if _, err = strconv.ParseFloat(repr, 32); s == "" || err == nil {
-				repr = `"` + repr + `"`
+
+	// Run test multiple times to ensure different orderings of Less
+	// have the same consistent output.
+	for i := 0; i < 100; i++ {
+		data, err := yaml.Marshal(m)
+		c.Assert(err, IsNil)
+		out := "\n" + string(data)
+		last := 0
+		for i, k := range order {
+			repr := fmt.Sprint(k)
+			if s, ok := k.(string); ok {
+				if _, err = strconv.ParseFloat(repr, 32); s == "" || err == nil {
+					repr = `"` + repr + `"`
+				}
 			}
+			index := strings.Index(out, "\n"+repr+":")
+			if index == -1 {
+				c.Fatalf("%#v is not in the output: %#v", k, out)
+			}
+			if index < last {
+				c.Fatalf("%#v was generated before %#v: %q", k, order[i-1], out)
+			}
+			last = index
 		}
-		index := strings.Index(out, "\n"+repr+":")
-		if index == -1 {
-			c.Fatalf("%#v is not in the output: %#v", k, out)
-		}
-		if index < last {
-			c.Fatalf("%#v was generated before %#v: %q", k, order[i-1], out)
-		}
-		last = index
 	}
 }

--- a/sorter.go
+++ b/sorter.go
@@ -39,7 +39,9 @@ func (l keyList) Less(i, j int) bool {
 	ar, br := []rune(a.String()), []rune(b.String())
 	for i := 0; i < len(ar) && i < len(br); i++ {
 		if ar[i] == br[i] {
-			continue
+			if !(unicode.IsDigit(ar[i]) && unicode.IsDigit(br[i])) {
+				continue
+			}
 		}
 		al := unicode.IsLetter(ar[i])
 		bl := unicode.IsLetter(br[i])
@@ -62,6 +64,9 @@ func (l keyList) Less(i, j int) bool {
 		}
 		if ai != bi {
 			return ai < bi
+		}
+		if ar[i] == br[i] {
+			continue
 		}
 		return ar[i] < br[i]
 	}


### PR DESCRIPTION
When comparing runes, don't skip equal runes if they are digits. This avoids issues when comparing values like `100` vs `11` since dropping the `1` causes a comparison of `00` vs `1`.

Fixes https://github.com/go-yaml/yaml/issues/194
