### PR TITLE
Updating license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package API for yaml v2 will remain stable as described in [gopkg.in](https:
 License
 -------
 
-The yaml package is licensed under the LGPL with an exception that allows it to be linked statically. Please see the LICENSE file for details.
+The yaml package is licensed under the Apache License, Version 2.0. Please see the LICENSE file for details.
 
 
 Example


### PR DESCRIPTION
@niemeyer I noticed the LICENSE file is now Apache, here's updated text for README.
