### PR TITLE
don't allow invalid durations

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -379,24 +379,28 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 		}
 		good = true
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		// The only valid types for durations are strings, nothing else
+		// can have a parseable unit
+		isDuration := out.Type() == durationType
+
 		switch resolved := resolved.(type) {
 		case int:
-			if !out.OverflowInt(int64(resolved)) {
+			if !isDuration && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				good = true
 			}
 		case int64:
-			if !out.OverflowInt(resolved) {
+			if !isDuration && !out.OverflowInt(resolved) {
 				out.SetInt(resolved)
 				good = true
 			}
 		case uint64:
-			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
+			if !isDuration && resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				good = true
 			}
 		case float64:
-			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
+			if !isDuration && resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				good = true
 			}

--- a/decode_test.go
+++ b/decode_test.go
@@ -958,6 +958,18 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 	c.Assert(v.A, DeepEquals, []int{2})
 }
 
+func (s *S) TestInvalidDuration(c *C) {
+	type Expected struct {
+		Dur time.Duration `yaml:"dur"`
+	}
+
+	var exp Expected
+	data := []byte(`dur: 15`)
+	err := yaml.Unmarshal(data, &exp)
+	c.Assert(err, ErrorMatches, "yaml: unmarshal errors:\n"+
+		"  line 1: cannot unmarshal !!int `15` into time.Duration")
+}
+
 //var data []byte
 //func init() {
 //	var err error


### PR DESCRIPTION
This fixes https://github.com/go-yaml/yaml/issues/200
