### PR TITLE
custom tags support

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -194,16 +194,21 @@ type decoder struct {
 }
 
 var (
-	mapItemType    = reflect.TypeOf(MapItem{})
-	durationType   = reflect.TypeOf(time.Duration(0))
-	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
-	ifaceType      = defaultMapType.Elem()
+	mapItemType     = reflect.TypeOf(MapItem{})
+	durationType    = reflect.TypeOf(time.Duration(0))
+	defaultMapType  = reflect.TypeOf(map[interface{}]interface{}{})
+	ifaceType       = defaultMapType.Elem()
+	tagUnmarshalers = map[string]TagUnmarshaler{}
 )
 
 func newDecoder() *decoder {
 	d := &decoder{mapType: defaultMapType}
 	d.aliases = make(map[string]bool)
 	return d
+}
+
+func registerCustomTagUnmarshaler(tag string, unmarshaler TagUnmarshaler) {
+	tagUnmarshalers[tag] = unmarshaler
 }
 
 func (d *decoder) terror(n *node, tag string, out reflect.Value) {
@@ -343,6 +348,12 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 				failf("!!binary value contains invalid base64 data")
 			}
 			resolved = string(data)
+		}
+		if unmarshaler, found := tagUnmarshalers[n.tag]; found {
+			resolved = unmarshaler.UnmarshalYAMLTag(n.value)
+			if out.Kind() == reflect.String && tag != yaml_BINARY_TAG {
+				n.value = resolved.(string)
+			}
 		}
 	}
 	if resolved == nil {

--- a/yaml.go
+++ b/yaml.go
@@ -32,6 +32,11 @@ type Unmarshaler interface {
 	UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
+// The Tag Unmarshaler interface
+type TagUnmarshaler interface {
+	UnmarshalYAMLTag(in string) interface{}
+}
+
 // The Marshaler interface may be implemented by types to customize their
 // behavior when being marshaled into a YAML document. The returned value
 // is marshaled in place of the original value implementing Marshaler.
@@ -143,6 +148,10 @@ func Marshal(in interface{}) (out []byte, err error) {
 	e.finish()
 	out = e.out
 	return
+}
+
+func RegisterTagUnmarshaler(tag string, unmarshaler TagUnmarshaler) {
+	registerCustomTagUnmarshaler(tag, unmarshaler)
 }
 
 func handleErr(err *error) {


### PR DESCRIPTION
i'd like to be able handle custom yaml tags; similar support is found in other language yaml implementations.  So this changes adds support to register a tag unmarshaler.  Please let me know if this is something you'd like to handle a different way & i'd be happy to modify it.
