### PR TITLE
Correctly quote date-like strings

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -306,6 +306,10 @@ var marshalTests = []struct {
 		map[string]time.Time{"a": time.Unix(1424801979, 0)},
 		"a: 2015-02-24T18:19:39Z\n",
 	},
+	{
+		map[string]string{"a": "2015-02-24T18:19:39Z"},
+		"a: '2015-02-24T18:19:39Z'\n",
+	},
 
 	// Ensure strings containing ": " are quoted (reported as PR #43, but not reproducible).
 	{


### PR DESCRIPTION
Fixes #192 

(this is a copy of #193, but since then, we've needed to move the fix to another branch)
