### PR TITLE
Fix for #215 Anchors don't decode to the same pointer + Allowing recursive references

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -278,7 +278,7 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 	switch n.kind {
 	case documentNode:
-		if good := d.document(n, out); good {
+		if good = d.document(n, out); good {
 			n.data = out.Addr().Interface()
 		}
 		return good

--- a/decode.go
+++ b/decode.go
@@ -192,8 +192,9 @@ type Decoder struct {
 }
 
 type DecoderOptions struct {
-	Strict    bool
-	Recursive bool
+	Strict     bool
+	Recursive  bool
+	StrictBool bool
 }
 
 // NewDecoder creates and initializes a new Decoder struct.
@@ -220,6 +221,11 @@ func NewDecoderWithOptions(options DecoderOptions) *Decoder {
 // SetStrict puts the decoder to strict mode
 func (d *Decoder) SetStrict(strict bool) {
 	d.options.Strict = strict
+}
+
+// SetStrict puts the decoder to strict boolean mode (According to the 1.2 YAML Spec)
+func (d *Decoder) SetStrictBool(strict bool) {
+	d.options.StrictBool = strict
 }
 
 // SetAllowRecursive allows to enable / disable the recursive parsing feature
@@ -433,6 +439,10 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 				failf("!!binary value contains invalid base64 data")
 			}
 			resolved = string(data)
+		} else if d.options.StrictBool && tag == yaml_BOOL_TAG {
+			if resolved != "true" && resolved != "false" {
+				tag = yaml_STR_TAG
+			}
 		}
 	}
 	if resolved == nil {

--- a/decode.go
+++ b/decode.go
@@ -683,7 +683,11 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 	var l = len(n.children)
 	for i := 0; i < l; i += 2 {
 		if isMerge(n.children[i]) {
-			d.merge(n.children[i+1], out)
+			tmp := reflect.ValueOf(map[interface{}]interface{}{})
+			d.merge(n.children[i+1], tmp)
+			for k, v := range tmp.Interface().(map[interface{}]interface{}) {
+				slice = append(slice, MapItem{k, v})
+			}
 			continue
 		}
 		item := MapItem{}

--- a/decode_test.go
+++ b/decode_test.go
@@ -945,6 +945,50 @@ func (s *S) TestMergeStruct(c *C) {
 	}
 }
 
+func (s *S) TestMapMerging(c *C) {
+	data := `---
+world: &world
+  greeting: Hello
+earth:
+  << : *world`
+
+	config := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte(data), &config)
+	if err != nil {
+		c.Errorf("Failed to parse\n%v\n\ninto a %T: %v", data, config, err)
+	}
+
+	earth := config["earth"]
+	expected := map[interface{}]interface{}{
+		"greeting": "Hello",
+	}
+
+	if !reflect.DeepEqual(earth, expected) {
+		c.Errorf("Merging does not work. Expected %v (%T), got %v (%T)", expected, expected, earth, earth)
+	}
+}
+
+func (s *S) TestMapSliceMerging(c *C) {
+	data := `---
+world: &world
+  greeting: Hello
+earth:
+  << : *world`
+
+	config := make(yaml.MapSlice, 0)
+	err := yaml.Unmarshal([]byte(data), &config)
+	if err != nil {
+		c.Errorf("Failed to parse\n%v\n\ninto a %T: %v", data, config, err)
+	}
+
+	earth := config[1].Value
+	expected := yaml.MapSlice{{Key: "greeting", Value: "Hello"}}
+
+	if !reflect.DeepEqual(earth, expected) {
+		c.Errorf("Merging does not work. Expected %v (%T), got %v (%T)", expected, expected, earth, earth)
+	}
+}
+
 var unmarshalNullTests = []func() interface{}{
 	func() interface{} { var v interface{}; v = "v"; return &v },
 	func() interface{} { var s = "s"; return &s },

--- a/encode.go
+++ b/encode.go
@@ -99,7 +99,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		}
 	case reflect.Struct:
 		e.structv(tag, in)
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		if in.Type().Elem() == mapItemType {
 			e.itemsv(tag, in)
 		} else {

--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 
 func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	defer handleErr(&err)
-	d := newDecoder(strict)
+    d := NewDecoderWithOptions(DecoderOptions{Strict: strict})
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()


### PR DESCRIPTION
This mainly is fixing Issue #215  however I have added at the same time support for recursive decoding, since those things should go basically hand in hand.

I took the liberty and rebased my changes on top of PR #210 because I can see that these changes would go the same way and would need a new parser as well. Therefore I added it on top of that.

Here is a test case where the new code comes into play:

```go
package main

import (
	"errors"
	"log"

	"gopkg.in/yaml.v2"
)

type NoopRes struct {
	Path    string  `yaml:"path"`
	Content *string `yaml:"content"` // XXX *string
}

type Recursive struct {
	Self *Recursive `yaml:"self"`
	This *Recursive `yaml:"this"`
	Name string     `yaml:"name"`
}

type GraphConfig struct {
	Graph     string `yaml:"graph"`
	Resources struct {
		Noop      []*NoopRes `yaml:"noop"`
		Recursive Recursive  `yaml:"other"`
	} `yaml:"resources"`
	Comment string `yaml:"comment"`
}

func (c *GraphConfig) Parse(data []byte) error {
    decoder := yaml.NewDecoder()
    decoder.SetAllowRecursive(true)
	if err := decoder.Unmarshal(data, c); err != nil {
		return err
	}
	if c.Graph == "" {
		return errors.New("Graph config: invalid `graph`")
	}
	return nil
}

func main() {
	log.Printf("Hello!")
	str :=
		`

---
graph: mygraph
comment: my comment
resources:
  noop:
  - name: noop1
    path: foo
    content: &ptr "hello"
  - name: noop2
    path: bar
    content: *ptr
  - name: noop3
    path: baz
    content: *ptr
  unused:
  - foo: bar
  other: &recursive
    self: *recursive
    this: *recursive
    name: Recursive item
`

	data := []byte(str)
	var config GraphConfig
	if err := config.Parse(data); err != nil {
		log.Printf("Config: Error: ParseConfigFromFile: Parse: %v", err)
		return
	}

	log.Printf("Success!")
	log.Printf("%+v", &config)
	log.Printf("%+v", config.Resources.Noop[0].Content)
	if x := config.Resources.Noop[0].Content; x != nil {
		log.Printf("inside: %+v", *config.Resources.Noop[0].Content)
	}

	log.Printf("================")

	log.Printf("%+v", config.Resources.Noop[1].Content)
	if x := config.Resources.Noop[1].Content; x != nil {
		log.Printf("inside: %+v", *x)
	} else {
		log.Printf("nothing inside!")
	}

	if config.Resources.Noop[0].Content != config.Resources.Noop[1].Content {
		log.Printf("different pointers! :( %v %v", config.Resources.Noop[0].Content, config.Resources.Noop[1].Content)
	} else {
		log.Printf("same pointers! :)")
	}

	log.Printf("================")

	log.Printf("%+v", config.Resources.Noop[2].Content)
	if x := config.Resources.Noop[2].Content; x != nil {
		log.Printf("inside: %+v", *x)
	} else {
		log.Printf("nothing inside!")
	}

	if config.Resources.Noop[1].Content != config.Resources.Noop[2].Content {
		log.Printf("different pointers! :( %v %v", config.Resources.Noop[1].Content, config.Resources.Noop[2].Content)
	} else {
		log.Printf("same pointers! :)")
	}
	log.Printf("Recursive.This.Self.This.Name: %s", config.Resources.Recursive.This.Self.This.Name)
	config.Resources.Recursive.This.Self.This.Name = "Modified Name"
	log.Printf("Recursive.This.Self.This.Name: %s", config.Resources.Recursive.This.Self.This.Self.This.Name)
}
```


    $ go run /tmp/test.go
    2016/11/02 17:00:06 Hello!
    2016/11/02 17:00:06 Success!
    2016/11/02 17:00:06 &{Graph:mygraph Resources:{Noop:[0xc42000caa0 0xc42000cb80 0xc42000cc40] Recursive:{Self:0xc42000ce00 This:0xc42000ce00 Name:Recursive item}} Comment:my comment}
    2016/11/02 17:00:06 0xc42000a8e0
    2016/11/02 17:00:06 inside: hello
    2016/11/02 17:00:06 ================
    2016/11/02 17:00:06 0xc42000a8e0
    2016/11/02 17:00:06 inside: hello
    2016/11/02 17:00:06 same pointers! :)
    2016/11/02 17:00:06 ================
    2016/11/02 17:00:06 0xc42000a8e0
    2016/11/02 17:00:06 inside: hello
    2016/11/02 17:00:06 same pointers! :)
    2016/11/02 17:00:06 Recursive.This.Self.This.Name: Recursive item
    2016/11/02 17:00:06 Recursive.This.Self.This.Name: Modified Name
