### PR TITLE
Add support for strict boolean parsing (Was #214)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -278,7 +278,7 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 	switch n.kind {
 	case documentNode:
-		if good := d.document(n, out); good {
+		if good = d.document(n, out); good {
 			n.data = out.Addr().Interface()
 		}
 		return good

--- a/decode.go
+++ b/decode.go
@@ -192,8 +192,9 @@ type Decoder struct {
 }
 
 type DecoderOptions struct {
-	Strict    bool
-	Recursive bool
+	Strict     bool
+	Recursive  bool
+	StrictBool bool
 }
 
 // NewDecoder creates and initializes a new Decoder struct.
@@ -220,6 +221,11 @@ func NewDecoderWithOptions(options DecoderOptions) *Decoder {
 // SetStrict puts the decoder to strict mode
 func (d *Decoder) SetStrict(strict bool) {
 	d.options.Strict = strict
+}
+
+// SetStrict puts the decoder to strict boolean mode (According to the 1.2 YAML Spec)
+func (d *Decoder) SetStrictBool(strict bool) {
+	d.options.StrictBool = strict
 }
 
 // SetAllowRecursive allows to enable / disable the recursive parsing feature
@@ -433,6 +439,10 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 				failf("!!binary value contains invalid base64 data")
 			}
 			resolved = string(data)
+		} else if d.options.StrictBool && tag == yaml_BOOL_TAG {
+			if resolved != "true" && resolved != "false" {
+				tag = yaml_STR_TAG
+			}
 		}
 	}
 	if resolved == nil {

--- a/encode.go
+++ b/encode.go
@@ -99,7 +99,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		}
 	case reflect.Struct:
 		e.structv(tag, in)
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		if in.Type().Elem() == mapItemType {
 			e.itemsv(tag, in)
 		} else {

--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 
 func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	defer handleErr(&err)
-	d := newDecoder(strict)
+    d := NewDecoderWithOptions(DecoderOptions{Strict: strict})
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()


### PR DESCRIPTION
This should help with kubernetes/kubernetes#34146

by introducing a new option to restrict the booleans to only `true` and `false`