### PR TITLE
Expose AST

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"encoding"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -19,13 +20,26 @@ const (
 )
 
 type Node struct {
-	kind         int
-	line, column int
-	tag          string
-	value        string
-	implicit     bool
-	children     []*Node
-	anchors      map[string]*Node
+	Kind         int
+	Line, Column int
+	Tag          string
+	Value        string
+	Implicit     bool
+	Children     []*Node
+	Anchors      map[string]*Node
+}
+
+// Parse parses the given bytes and returns the document node. It's useful
+// for directly accessing the AST of the YAML document.
+func Parse(b []byte) (*Node, error) {
+	parser, err := newParser(b)
+	if err != nil {
+		return nil, err
+	}
+
+	defer parser.destroy()
+
+	return parser.parse()
 }
 
 // ----------------------------------------------------------------------------
@@ -37,10 +51,10 @@ type parser struct {
 	doc    *Node
 }
 
-func newParser(b []byte) *parser {
+func newParser(b []byte) (*parser, error) {
 	p := parser{}
 	if !yaml_parser_initialize(&p.parser) {
-		panic("failed to initialize YAML emitter")
+		return nil, errors.New("failed to initialize YAML emitter")
 	}
 
 	if len(b) == 0 {
@@ -51,10 +65,10 @@ func newParser(b []byte) *parser {
 
 	p.skip()
 	if p.event.typ != yaml_STREAM_START_EVENT {
-		panic("expected stream start event, got " + strconv.Itoa(int(p.event.typ)))
+		return nil, errors.New("expected stream start event, got " + strconv.Itoa(int(p.event.typ)))
 	}
 	p.skip()
-	return &p
+	return &p, nil
 }
 
 func (p *parser) destroy() {
@@ -98,16 +112,16 @@ func (p *parser) fail() {
 
 func (p *parser) anchor(n *Node, anchor []byte) {
 	if anchor != nil {
-		p.doc.anchors[string(anchor)] = n
+		p.doc.Anchors[string(anchor)] = n
 	}
 }
 
-func (p *parser) parse() *Node {
+func (p *parser) parse() (*Node, error) {
 	switch p.event.typ {
 	case yaml_SCALAR_EVENT:
-		return p.scalar()
+		return p.scalar(), nil
 	case yaml_ALIAS_EVENT:
-		return p.alias()
+		return p.alias(), nil
 	case yaml_MAPPING_START_EVENT:
 		return p.mapping()
 	case yaml_SEQUENCE_START_EVENT:
@@ -116,71 +130,87 @@ func (p *parser) parse() *Node {
 		return p.document()
 	case yaml_STREAM_END_EVENT:
 		// Happens when attempting to decode an empty buffer.
-		return nil
+		return nil, nil
 	default:
-		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
+		return nil, errors.New("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
 	}
 	panic("unreachable")
 }
 
 func (p *parser) node(kind int) *Node {
 	return &Node{
-		kind:   kind,
-		line:   p.event.start_mark.line,
-		column: p.event.start_mark.column,
+		Kind:   kind,
+		Line:   p.event.start_mark.line,
+		Column: p.event.start_mark.column,
 	}
 }
 
-func (p *parser) document() *Node {
+func (p *parser) document() (*Node, error) {
 	n := p.node(DocumentNode)
-	n.anchors = make(map[string]*Node)
+	n.Anchors = make(map[string]*Node)
 	p.doc = n
 	p.skip()
-	n.children = append(n.children, p.parse())
+	children, err := p.parse()
+	if err != nil {
+		return nil, err
+	}
+	n.Children = append(n.Children, children)
 	if p.event.typ != yaml_DOCUMENT_END_EVENT {
-		panic("expected end of document event but got " + strconv.Itoa(int(p.event.typ)))
+		return nil, errors.New("expected end of document event but got " + strconv.Itoa(int(p.event.typ)))
 	}
 	p.skip()
-	return n
+	return n, nil
 }
 
 func (p *parser) alias() *Node {
 	n := p.node(AliasNode)
-	n.value = string(p.event.anchor)
+	n.Value = string(p.event.anchor)
 	p.skip()
 	return n
 }
 
 func (p *parser) scalar() *Node {
 	n := p.node(ScalarNode)
-	n.value = string(p.event.value)
-	n.tag = string(p.event.tag)
-	n.implicit = p.event.implicit
+	n.Value = string(p.event.value)
+	n.Tag = string(p.event.tag)
+	n.Implicit = p.event.implicit
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	return n
 }
 
-func (p *parser) sequence() *Node {
+func (p *parser) sequence() (*Node, error) {
 	n := p.node(SequenceNode)
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	for p.event.typ != yaml_SEQUENCE_END_EVENT {
-		n.children = append(n.children, p.parse())
+		children, err := p.parse()
+		if err != nil {
+			return nil, err
+		}
+		n.Children = append(n.Children, children)
 	}
 	p.skip()
-	return n
+	return n, nil
 }
 
-func (p *parser) mapping() *Node {
+func (p *parser) mapping() (*Node, error) {
 	n := p.node(MappingNode)
 	p.anchor(n, p.event.anchor)
 	p.skip()
 	for p.event.typ != yaml_MAPPING_END_EVENT {
-		n.children = append(n.children, p.parse(), p.parse())
+		key, err := p.parse()
+		if err != nil {
+			return nil, err
+		}
+		value, err := p.parse()
+		if err != nil {
+			return nil, err
+		}
+		n.Children = append(n.Children, key, value)
 	}
 	p.skip()
-	return n
+	return n, nil
 }
 
 // ----------------------------------------------------------------------------
@@ -207,10 +237,10 @@ func newDecoder() *decoder {
 }
 
 func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
-	if n.tag != "" {
-		tag = n.tag
+	if n.Tag != "" {
+		tag = n.Tag
 	}
-	value := n.value
+	value := n.Value
 	if tag != yaml_SEQ_TAG && tag != yaml_MAP_TAG {
 		if len(value) > 10 {
 			value = " `" + value[:7] + "...`"
@@ -218,7 +248,7 @@ func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 			value = " `" + value + "`"
 		}
 	}
-	d.terrors = append(d.terrors, fmt.Sprintf("line %d: cannot unmarshal %s%s into %s", n.line+1, shortTag(tag), value, out.Type()))
+	d.terrors = append(d.terrors, fmt.Sprintf("line %d: cannot unmarshal %s%s into %s", n.Line+1, shortTag(tag), value, out.Type()))
 }
 
 func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
@@ -251,7 +281,7 @@ func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == ScalarNode && n.tag == "" && (n.value == "null" || n.value == "" && n.implicit) {
+	if n.Tag == yaml_NULL_TAG || n.Kind == ScalarNode && n.Tag == "" && (n.Value == "null" || n.Value == "" && n.Implicit) {
 		return out, false, false
 	}
 	again := true
@@ -275,7 +305,7 @@ func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unm
 }
 
 func (d *decoder) unmarshal(n *Node, out reflect.Value) (good bool) {
-	switch n.kind {
+	switch n.Kind {
 	case DocumentNode:
 		return d.document(n, out)
 	case AliasNode:
@@ -285,7 +315,7 @@ func (d *decoder) unmarshal(n *Node, out reflect.Value) (good bool) {
 	if unmarshaled {
 		return good
 	}
-	switch n.kind {
+	switch n.Kind {
 	case ScalarNode:
 		good = d.scalar(n, out)
 	case MappingNode:
@@ -293,31 +323,31 @@ func (d *decoder) unmarshal(n *Node, out reflect.Value) (good bool) {
 	case SequenceNode:
 		good = d.sequence(n, out)
 	default:
-		panic("internal error: unknown node kind: " + strconv.Itoa(n.kind))
+		panic("internal error: unknown node kind: " + strconv.Itoa(n.Kind))
 	}
 	return good
 }
 
 func (d *decoder) document(n *Node, out reflect.Value) (good bool) {
-	if len(n.children) == 1 {
+	if len(n.Children) == 1 {
 		d.doc = n
-		d.unmarshal(n.children[0], out)
+		d.unmarshal(n.Children[0], out)
 		return true
 	}
 	return false
 }
 
 func (d *decoder) alias(n *Node, out reflect.Value) (good bool) {
-	an, ok := d.doc.anchors[n.value]
+	an, ok := d.doc.Anchors[n.Value]
 	if !ok {
-		failf("unknown anchor '%s' referenced", n.value)
+		failf("unknown anchor '%s' referenced", n.Value)
 	}
-	if d.aliases[n.value] {
-		failf("anchor '%s' value contains itself", n.value)
+	if d.aliases[n.Value] {
+		failf("anchor '%s' value contains itself", n.Value)
 	}
-	d.aliases[n.value] = true
+	d.aliases[n.Value] = true
 	good = d.unmarshal(an, out)
-	delete(d.aliases, n.value)
+	delete(d.aliases, n.Value)
 	return good
 }
 
@@ -332,11 +362,11 @@ func resetMap(out reflect.Value) {
 func (d *decoder) scalar(n *Node, out reflect.Value) (good bool) {
 	var tag string
 	var resolved interface{}
-	if n.tag == "" && !n.implicit {
+	if n.Tag == "" && !n.Implicit {
 		tag = yaml_STR_TAG
-		resolved = n.value
+		resolved = n.Value
 	} else {
-		tag, resolved = resolve(n.tag, n.value)
+		tag, resolved = resolve(n.Tag, n.Value)
 		if tag == yaml_BINARY_TAG {
 			data, err := base64.StdEncoding.DecodeString(resolved.(string))
 			if err != nil {
@@ -368,7 +398,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) (good bool) {
 			out.SetString(resolved.(string))
 			good = true
 		} else if resolved != nil {
-			out.SetString(n.value)
+			out.SetString(n.Value)
 			good = true
 		}
 	case reflect.Interface:
@@ -476,7 +506,7 @@ func settableValueOf(i interface{}) reflect.Value {
 }
 
 func (d *decoder) sequence(n *Node, out reflect.Value) (good bool) {
-	l := len(n.children)
+	l := len(n.Children)
 
 	var iface reflect.Value
 	switch out.Kind() {
@@ -495,7 +525,7 @@ func (d *decoder) sequence(n *Node, out reflect.Value) (good bool) {
 	j := 0
 	for i := 0; i < l; i++ {
 		e := reflect.New(et).Elem()
-		if ok := d.unmarshal(n.children[i], e); ok {
+		if ok := d.unmarshal(n.Children[i], e); ok {
 			out.Index(j).Set(e)
 			j++
 		}
@@ -544,14 +574,14 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 	if out.IsNil() {
 		out.Set(reflect.MakeMap(outt))
 	}
-	l := len(n.children)
+	l := len(n.Children)
 	for i := 0; i < l; i += 2 {
-		if isMerge(n.children[i]) {
-			d.merge(n.children[i+1], out)
+		if isMerge(n.Children[i]) {
+			d.merge(n.Children[i+1], out)
 			continue
 		}
 		k := reflect.New(kt).Elem()
-		if d.unmarshal(n.children[i], k) {
+		if d.unmarshal(n.Children[i], k) {
 			kkind := k.Kind()
 			if kkind == reflect.Interface {
 				kkind = k.Elem().Kind()
@@ -560,7 +590,7 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 				failf("invalid map key: %#v", k.Interface())
 			}
 			e := reflect.New(et).Elem()
-			if d.unmarshal(n.children[i+1], e) {
+			if d.unmarshal(n.Children[i+1], e) {
 				out.SetMapIndex(k, e)
 			}
 		}
@@ -580,17 +610,17 @@ func (d *decoder) mappingSlice(n *Node, out reflect.Value) (good bool) {
 	d.mapType = outt
 
 	var slice []MapItem
-	var l = len(n.children)
+	var l = len(n.Children)
 	for i := 0; i < l; i += 2 {
-		if isMerge(n.children[i]) {
-			d.merge(n.children[i+1], out)
+		if isMerge(n.Children[i]) {
+			d.merge(n.Children[i+1], out)
 			continue
 		}
 		item := MapItem{}
 		k := reflect.ValueOf(&item.Key).Elem()
-		if d.unmarshal(n.children[i], k) {
+		if d.unmarshal(n.Children[i], k) {
 			v := reflect.ValueOf(&item.Value).Elem()
-			if d.unmarshal(n.children[i+1], v) {
+			if d.unmarshal(n.Children[i+1], v) {
 				slice = append(slice, item)
 			}
 		}
@@ -606,7 +636,7 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 		panic(err)
 	}
 	name := settableValueOf("")
-	l := len(n.children)
+	l := len(n.Children)
 
 	var inlineMap reflect.Value
 	var elemType reflect.Type
@@ -617,9 +647,9 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 	}
 
 	for i := 0; i < l; i += 2 {
-		ni := n.children[i]
+		ni := n.Children[i]
 		if isMerge(ni) {
-			d.merge(n.children[i+1], out)
+			d.merge(n.Children[i+1], out)
 			continue
 		}
 		if !d.unmarshal(ni, name) {
@@ -632,13 +662,13 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 			} else {
 				field = out.FieldByIndex(info.Inline)
 			}
-			d.unmarshal(n.children[i+1], field)
+			d.unmarshal(n.Children[i+1], field)
 		} else if sinfo.InlineMap != -1 {
 			if inlineMap.IsNil() {
 				inlineMap.Set(reflect.MakeMap(inlineMap.Type()))
 			}
 			value := reflect.New(elemType).Elem()
-			d.unmarshal(n.children[i+1], value)
+			d.unmarshal(n.Children[i+1], value)
 			inlineMap.SetMapIndex(name, value)
 		}
 	}
@@ -650,25 +680,25 @@ func failWantMap() {
 }
 
 func (d *decoder) merge(n *Node, out reflect.Value) {
-	switch n.kind {
+	switch n.Kind {
 	case MappingNode:
 		d.unmarshal(n, out)
 	case AliasNode:
-		an, ok := d.doc.anchors[n.value]
-		if ok && an.kind != MappingNode {
+		an, ok := d.doc.Anchors[n.Value]
+		if ok && an.Kind != MappingNode {
 			failWantMap()
 		}
 		d.unmarshal(n, out)
 	case SequenceNode:
 		// Step backwards as earlier nodes take precedence.
-		for i := len(n.children) - 1; i >= 0; i-- {
-			ni := n.children[i]
-			if ni.kind == AliasNode {
-				an, ok := d.doc.anchors[ni.value]
-				if ok && an.kind != MappingNode {
+		for i := len(n.Children) - 1; i >= 0; i-- {
+			ni := n.Children[i]
+			if ni.Kind == AliasNode {
+				an, ok := d.doc.Anchors[ni.Value]
+				if ok && an.Kind != MappingNode {
 					failWantMap()
 				}
-			} else if ni.kind != MappingNode {
+			} else if ni.Kind != MappingNode {
 				failWantMap()
 			}
 			d.unmarshal(ni, out)
@@ -679,5 +709,5 @@ func (d *decoder) merge(n *Node, out reflect.Value) {
 }
 
 func isMerge(n *Node) bool {
-	return n.kind == ScalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
+	return n.Kind == ScalarNode && n.Value == "<<" && (n.Implicit == true || n.Tag == yaml_MERGE_TAG)
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,13 +2,14 @@ package yaml_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/commondream/yaml"
+	. "gopkg.in/check.v1"
 )
 
 var unmarshalIntTest = 123

--- a/decode_test.go
+++ b/decode_test.go
@@ -988,3 +988,17 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 //		yaml.Marshal(&v)
 //	}
 //}
+
+func (s *S) TestParse(c *C) {
+	template := "v: 5"
+	node, _ := yaml.Parse([]byte(template))
+
+	if node != nil {
+		c.Assert(node.Kind, Equals, yaml.DocumentNode)
+		c.Assert(len(node.Children), Equals, 1)
+
+		child := node.Children[0]
+		c.Assert(len(child.Children), Equals, 2)
+		c.Assert(child.Children[1].Implicit, Equals, true)
+	}
+}

--- a/yaml.go
+++ b/yaml.go
@@ -79,9 +79,17 @@ type Marshaler interface {
 func Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
 	d := newDecoder()
-	p := newParser(in)
+	p, err := newParser(in)
+	if err != nil {
+		return err
+	}
 	defer p.destroy()
-	node := p.parse()
+
+	node, err := p.parse()
+	if err != nil {
+		return err
+	}
+
 	if node != nil {
 		v := reflect.ValueOf(out)
 		if v.Kind() == reflect.Ptr && !v.IsNil() {


### PR DESCRIPTION
This PR exposes the types and fields needed to expose the AST. It also adds a new `Parse` function that returns the document node for a document.

This functionality is handy because it allows more raw access of the yaml document.