### PR TITLE
Update the yamlStyleFloat regex for special case.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -43,6 +43,9 @@ var unmarshalTests = []struct {
 		"v: 0xA",
 		map[string]interface{}{"v": 10},
 	}, {
+		"v: 01182252",
+		map[string]interface{}{"v": "01182252"},
+	}, {
 		"v: 4294967296",
 		map[string]int64{"v": 4294967296},
 	}, {

--- a/resolve.go
+++ b/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(0|[1-9][0-9]*)?(\.[0-9]+)?([eE][-+][0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {


### PR DESCRIPTION
Fixes #157 by updating the regex for float matching.

Instead of allowing mantissa to be any 0-9 sequence, this change means it must be either 0, or not start with a zero.