### PR TITLE
Add nowrap tag to ensure that values are outputted on to a single line

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -314,7 +314,7 @@ func yaml_document_end_event_initialize(event *yaml_event_t, implicit bool) bool
 //}
 
 // Create SCALAR.
-func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yaml_scalar_style_t) bool {
+func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yaml_scalar_style_t, info fieldInfo) bool {
 	*event = yaml_event_t{
 		typ:             yaml_SCALAR_EVENT,
 		anchor:          anchor,
@@ -323,6 +323,7 @@ func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte
 		implicit:        plain_implicit,
 		quoted_implicit: quoted_implicit,
 		style:           yaml_style_t(style),
+		allow_breaks:    !info.NoWrap,
 	}
 	return true
 }

--- a/emitterc.go
+++ b/emitterc.go
@@ -891,13 +891,13 @@ func yaml_emitter_process_tag(emitter *yaml_emitter_t) bool {
 func yaml_emitter_process_scalar(emitter *yaml_emitter_t) bool {
 	switch emitter.scalar_data.style {
 	case yaml_PLAIN_SCALAR_STYLE:
-		return yaml_emitter_write_plain_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+		return yaml_emitter_write_plain_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context && emitter.scalar_data.allow_breaks)
 
 	case yaml_SINGLE_QUOTED_SCALAR_STYLE:
-		return yaml_emitter_write_single_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+		return yaml_emitter_write_single_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context && emitter.scalar_data.allow_breaks)
 
 	case yaml_DOUBLE_QUOTED_SCALAR_STYLE:
-		return yaml_emitter_write_double_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context)
+		return yaml_emitter_write_double_quoted_scalar(emitter, emitter.scalar_data.value, !emitter.simple_key_context && emitter.scalar_data.allow_breaks)
 
 	case yaml_LITERAL_SCALAR_STYLE:
 		return yaml_emitter_write_literal_scalar(emitter, emitter.scalar_data.value)
@@ -981,7 +981,7 @@ func yaml_emitter_analyze_tag(emitter *yaml_emitter_t, tag []byte) bool {
 }
 
 // Check if a scalar is valid.
-func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
+func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte, allow_breaks bool) bool {
 	var (
 		block_indicators   = false
 		flow_indicators    = false
@@ -1002,6 +1002,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 	)
 
 	emitter.scalar_data.value = value
+	emitter.scalar_data.allow_breaks = allow_breaks
 
 	if len(value) == 0 {
 		emitter.scalar_data.multiline = false
@@ -1154,7 +1155,7 @@ func yaml_emitter_analyze_event(emitter *yaml_emitter_t, event *yaml_event_t) bo
 				return false
 			}
 		}
-		if !yaml_emitter_analyze_scalar(emitter, event.value) {
+		if !yaml_emitter_analyze_scalar(emitter, event.value, event.allow_breaks) {
 			return false
 		}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -218,6 +218,14 @@ var marshalTests = []struct {
 		"a: {b: c, d: e}\n",
 	},
 
+	// No wrapping flag
+	{
+		&struct {
+			A string "a,nowrap"
+		}{ "When I have more than 100 characters in a single line and have now wrap I should not be wrapped. This string is being used to test this."},
+		"a: When I have more than 100 characters in a single line and have now wrap I should not be wrapped. This string is being used to test this.\n",
+	},
+
 	// Unexported field
 	{
 		&struct {

--- a/yaml.go
+++ b/yaml.go
@@ -139,7 +139,7 @@ func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
 	defer e.destroy()
-	e.marshal("", reflect.ValueOf(in))
+	e.marshal("", reflect.ValueOf(in), fieldInfo{})
 	e.finish()
 	out = e.out
 	return
@@ -200,6 +200,7 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	NoWrap    bool
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -247,6 +248,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.Flow = true
 				case "inline":
 					inline = true
+				case "nowrap":
+					info.NoWrap = true
 				default:
 					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
 				}

--- a/yamlh.go
+++ b/yamlh.go
@@ -275,6 +275,9 @@ type yaml_event_t struct {
 
 	// The style (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT).
 	style yaml_style_t
+
+	// The flag for if there should be line breaks allowed during the value.
+	allow_breaks bool
 }
 
 func (e *yaml_event_t) scalar_style() yaml_scalar_style_t     { return yaml_scalar_style_t(e.style) }
@@ -696,6 +699,7 @@ type yaml_emitter_t struct {
 		single_quoted_allowed bool                // Can the scalar be expressed in the single quoted style?
 		block_allowed         bool                // Can the scalar be expressed in the literal or folded styles?
 		style                 yaml_scalar_style_t // The output style.
+		allow_breaks          bool                // Are line breaks allowed in this scalar while being expressed?
 	}
 
 	// Dumper stuff


### PR DESCRIPTION
This adds a no wrap tag to allow for people to avoid having unwanted line breaks in their values.

It also allows for the adding of other such tags to be done in an easier fashion.

