### PR TITLE
make TextUnmarshaler errors non-fatal, add line number

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -357,7 +357,8 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 		if u, ok := out.Addr().Interface().(encoding.TextUnmarshaler); ok {
 			err := u.UnmarshalText([]byte(s))
 			if err != nil {
-				fail(err)
+				d.terrors = append(d.terrors, fmt.Sprintf("line %d: %v", n.line+1, err))
+				return false
 			}
 			return true
 		}


### PR DESCRIPTION
TextUnmarshaler is commonly used for 'small' types such as IP addresses.
If a parse error occurs with such a type, the current behavior is to
break out of parsing and return that error directly. When package yaml
is used to process configuration files, it is more appropriate to emit a
parser errror with line number info and continue.

This changes API behavior, but I cannot imagine a use case where one
would rely on yaml returning the exact error from UnmarshalText. Support
for TextUnmarshaler isn't even documented.