### PR TITLE
Fix for issue #245

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -546,7 +546,7 @@ func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 	}
 	l := len(n.children)
 	for i := 0; i < l; i += 2 {
-		if isMerge(n.children[i]) {
+		if isMerge(n.children[i], n.children[i+1]) {
 			d.merge(n.children[i+1], out)
 			continue
 		}
@@ -582,7 +582,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 	var slice []MapItem
 	var l = len(n.children)
 	for i := 0; i < l; i += 2 {
-		if isMerge(n.children[i]) {
+		if isMerge(n.children[i], n.children[i+1]) {
 			d.merge(n.children[i+1], out)
 			continue
 		}
@@ -618,7 +618,7 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 
 	for i := 0; i < l; i += 2 {
 		ni := n.children[i]
-		if isMerge(ni) {
+		if isMerge(ni, n.children[i+1]) {
 			d.merge(n.children[i+1], out)
 			continue
 		}
@@ -678,6 +678,6 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 	}
 }
 
-func isMerge(n *node) bool {
-	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
+func isMerge(n *node, nn *node) bool {
+	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG) && nn.kind != scalarNode
 }

--- a/decode.go
+++ b/decode.go
@@ -679,5 +679,5 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 }
 
 func isMerge(n *node, nn *node) bool {
-	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG) && nn.kind != scalarNode
+	return n.tag == yaml_MERGE_TAG || n.kind == scalarNode && n.value == "<<" && n.implicit == true && nn.kind != scalarNode
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -937,6 +937,13 @@ func (s *S) TestMergeStruct(c *C) {
 	}
 }
 
+func (s *S) TestDontMergeScalarNode(c *C) {
+	value := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte("<<: value"), &value)
+	c.Assert(err, IsNil)
+	c.Assert(value["<<"], Equals, "value")
+}
+
 var unmarshalNullTests = []func() interface{}{
 	func() interface{} { var v interface{}; v = "v"; return &v },
 	func() interface{} { var s = "s"; return &s },

--- a/decode_test.go
+++ b/decode_test.go
@@ -944,6 +944,12 @@ func (s *S) TestDontMergeScalarNode(c *C) {
 	c.Assert(value["<<"], Equals, "value")
 }
 
+func (s *S) TestFailExplicitMergeScalarNode(c *C) {
+	value := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte("!!merge <<: value"), &value)
+	c.Assert(err, ErrorMatches, ".*map merge requires map or sequence of maps as the value")
+}
+
 var unmarshalNullTests = []func() interface{}{
 	func() interface{} { var v interface{}; v = "v"; return &v },
 	func() interface{} { var s = "s"; return &s },


### PR DESCRIPTION
As outlined in issue #245 we have YAML files containing "<<" as key names for values that should (and cannot be merged) according to http://yaml.org/type/merge.html. The proposed fix checks if the value node is of type 'scalar node' and then does not try to merge; unless explicitly requested (i.e. by adding the !!merge tag).
