### PR TITLE
Reject duplicate keys (addresses #154)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -176,8 +176,16 @@ func (p *parser) mapping() *node {
 	n := p.node(mappingNode)
 	p.anchor(n, p.event.anchor)
 	p.skip()
+	duplicates := make(map[string]bool)
 	for p.event.typ != yaml_MAPPING_END_EVENT {
-		n.children = append(n.children, p.parse(), p.parse())
+		key := p.parse()
+		value := p.parse()
+		if _, exists := duplicates[key.value]; exists {
+			p.parser.problem = fmt.Sprintf("duplicate key %#v", key.value)
+			p.fail()
+		}
+		duplicates[key.value] = true
+		n.children = append(n.children, key, value)
 	}
 	p.skip()
 	return n

--- a/decode.go
+++ b/decode.go
@@ -181,6 +181,7 @@ func (p *parser) mapping() *node {
 		key := p.parse()
 		value := p.parse()
 		if _, exists := duplicates[key.value]; exists {
+			p.parser.problem_mark.line = p.event.start_mark.line
 			p.parser.problem = fmt.Sprintf("duplicate key %#v", key.value)
 			p.fail()
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -663,7 +663,7 @@ var unmarshalErrorTests = []struct {
 	{"a: !!binary ==", "yaml: !!binary value contains invalid base64 data"},
 	{"{[.]}", `yaml: invalid map key: \[\]interface \{\}\{"\."\}`},
 	{"{{.}}", `yaml: invalid map key: map\[interface\ \{\}\]interface \{\}\{".":interface \{\}\(nil\)\}`},
-	{"a: 0\na: 1", `yaml: duplicate key "a"`},
+	{"a: 3\nb: 0\nb: 1", `yaml: line 3: duplicate key "b"`},
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {


### PR DESCRIPTION
This addresses https://github.com/go-yaml/yaml/issues/154 (reject duplicate keys in mappings as per [the spec](http://yaml.org/spec/1.2/spec.html#id2764044))