### PR TITLE
Add support for an octal type

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -195,6 +195,7 @@ type decoder struct {
 var (
 	mapItemType    = reflect.TypeOf(MapItem{})
 	durationType   = reflect.TypeOf(time.Duration(0))
+	octalType      = reflect.TypeOf(Octal(0))
 	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
 	ifaceType      = defaultMapType.Elem()
 )

--- a/decode_test.go
+++ b/decode_test.go
@@ -502,6 +502,12 @@ var unmarshalTests = []struct {
 		map[string]time.Duration{"a": 3 * time.Second},
 	},
 
+	// Octal
+	{
+		"a: 0660",
+		map[string]yaml.Octal{"a": 432},
+	},
+
 	// Issue #24.
 	{
 		"a: <foo>",

--- a/encode.go
+++ b/encode.go
@@ -110,6 +110,8 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if in.Type() == durationType {
 			e.stringv(tag, reflect.ValueOf(iface.(time.Duration).String()))
+		} else if in.Type() == octalType {
+			e.octalv(tag, reflect.ValueOf(iface.(Octal).String()))
 		} else {
 			e.intv(tag, in)
 		}
@@ -274,6 +276,10 @@ func (e *encoder) boolv(tag string, in reflect.Value) {
 func (e *encoder) intv(tag string, in reflect.Value) {
 	s := strconv.FormatInt(in.Int(), 10)
 	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) octalv(tag string, in reflect.Value) {
+	e.emitScalar(in.String(), "", tag, yaml_PLAIN_SCALAR_STYLE)
 }
 
 func (e *encoder) uintv(tag string, in reflect.Value) {

--- a/octal.go
+++ b/octal.go
@@ -1,0 +1,41 @@
+package yaml
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Octal is an int64 that represents an octal number.
+type Octal int64
+
+// String converts the given octal number to a string
+// with a leading "0".
+func (o Octal) String() string {
+	return fmt.Sprintf("%#o", int64(o))
+}
+
+// Int64 returns the Octal number as an int64
+func (number Octal) Int64() int64 {
+	return int64(number)
+}
+
+// New takes an octal number as a string and returns
+// an int64 as the Octal type, or 0. Use New2() for better
+// error handling.
+func New(octal string) Octal {
+	number, err := strconv.ParseInt(octal, 8, 64)
+	if err != nil {
+		return 0
+	}
+	return Octal(number)
+}
+
+// New2 takes an octal number as a string and returns
+// an int64 as the Octal type, along with an error value.
+func New2(octal string) (Octal, error) {
+	number, err := strconv.ParseInt(octal, 8, 64)
+	if err != nil {
+		return 0, err
+	}
+	return Octal(number), nil
+}

--- a/octal_test.go
+++ b/octal_test.go
@@ -1,0 +1,21 @@
+package yaml
+
+import (
+	"testing"
+)
+
+func TestOctal(t *testing.T) {
+	o := New("0660")
+	n := o.Int64()
+	if n != 432 {
+		t.Error("The octal conversion is wrong, the result was: ", n)
+	}
+}
+
+func TestOctalString(t *testing.T) {
+	o := New("0775")
+	s := o.String()
+	if s != "0775" {
+		t.Error("The octal string conversion is wrong, the result was: ", s)
+	}
+}


### PR DESCRIPTION
File permissions in YAML files are more intuitive when written like `0660` rather than `432`.

I see you already have a check in place for `time.Duration`, so I added one for an `Octal` type too.

This is only for writing numbers as octal, `go-yaml/yaml` can already read octal numbers just fine.

I'm not saying this is the perfect solution, but it worked for me.

Cheers!