### PR TITLE
docs: note need for public struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ b:
   d: [3, 4]
 `
 
+// Note: struct fields must be public
+// in order for unmarshal to correctly
+// populate the data.
 type T struct {
         A string
         B struct {

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ b:
   d: [3, 4]
 `
 
-// Note: struct fields must be public
-// in order for unmarshal to correctly
-// populate the data.
+// Note: struct fields must be public in order for unmarshal to
+// correctly populate the data.
 type T struct {
         A string
         B struct {


### PR DESCRIPTION
It took me longer than it should have to realise that struct fields need to be public for unmarshal to work correctly. Just adding a quick note to that effect. 