### PR TITLE
encoder.marshal panics on nil pointers

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -60,7 +60,7 @@ func (e *encoder) must(ok bool) {
 }
 
 func (e *encoder) marshal(tag string, in reflect.Value) {
-	if !in.IsValid() {
+	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
 		e.nilv()
 		return
 	}


### PR DESCRIPTION
func (e *encoder) marshal(tag string, in reflect.Value) should not try to perform any operations (call MarshalYAML() or MarshalText()) on nil pointers