### PR TITLE
Inner flow sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,39 +63,42 @@ a: Easy!
 b:
   c: 2
   d: [3, 4]
+  e:
+  - [5, 6]
 `
 
 type T struct {
         A string
         B struct {
-                RenamedC int   `yaml:"c"`
-                D        []int `yaml:",flow"`
+                RenamedC int     `yaml:"c"`
+                D        []int   `yaml:",flow"`
+                E        [][]int `yaml:",innerflow"`
         }
 }
 
 func main() {
         t := T{}
-    
+
         err := yaml.Unmarshal([]byte(data), &t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t:\n%v\n\n", t)
-    
+
         d, err := yaml.Marshal(&t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t dump:\n%s\n\n", string(d))
-    
+
         m := make(map[interface{}]interface{})
-    
+
         err = yaml.Unmarshal([]byte(data), &m)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- m:\n%v\n\n", m)
-    
+
         d, err = yaml.Marshal(&m)
         if err != nil {
                 log.Fatalf("error: %v", err)
@@ -108,17 +111,19 @@ This example will generate the following output:
 
 ```
 --- t:
-{Easy! {2 [3 4]}}
+{Easy! {2 [3 4] [[5 6]]}}
 
 --- t dump:
 a: Easy!
 b:
   c: 2
   d: [3, 4]
+  e:
+  - [5, 6]
 
 
 --- m:
-map[a:Easy! b:map[c:2 d:[3 4]]]
+map[a:Easy! b:map[c:2 d:[3 4] e:[[5 6]]]]
 
 --- m dump:
 a: Easy!
@@ -127,5 +132,7 @@ b:
   d:
   - 3
   - 4
+  e:
+  - - 5
+    - 6
 ```
-

--- a/emitterc.go
+++ b/emitterc.go
@@ -1,8 +1,6 @@
 package yaml
 
-import (
-	"bytes"
-)
+import "bytes"
 
 // Flush the buffer if needed.
 func flush(emitter *yaml_emitter_t) bool {
@@ -231,6 +229,12 @@ func yaml_emitter_state_machine(emitter *yaml_emitter_t, event *yaml_event_t) bo
 
 	case yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE:
 		return yaml_emitter_emit_flow_sequence_item(emitter, event, false)
+
+	case yaml_EMIT_INNER_FLOW_SEQUENCE_FIRST_ITEM_STATE:
+		return yaml_emitter_emit_inner_flow_sequence_item(emitter, event, true)
+
+	case yaml_EMIT_INNER_FLOW_SEQUENCE_ITEM_STATE:
+		return yaml_emitter_emit_inner_flow_sequence_item(emitter, event, false)
 
 	case yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE:
 		return yaml_emitter_emit_flow_mapping_key(emitter, event, true)
@@ -500,6 +504,32 @@ func yaml_emitter_emit_flow_sequence_item(emitter *yaml_emitter_t, event *yaml_e
 	return yaml_emitter_emit_node(emitter, event, false, true, false, false)
 }
 
+// Expect an inner flow item node.
+func yaml_emitter_emit_inner_flow_sequence_item(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
+	if first {
+		if !yaml_emitter_increase_indent(emitter, false, emitter.mapping_context && !emitter.indention) {
+			return false
+		}
+		emitter.inner_flow_level++
+	}
+	if event.typ == yaml_SEQUENCE_END_EVENT {
+		emitter.inner_flow_level--
+		emitter.indent = emitter.indents[len(emitter.indents)-1]
+		emitter.indents = emitter.indents[:len(emitter.indents)-1]
+		emitter.state = emitter.states[len(emitter.states)-1]
+		emitter.states = emitter.states[:len(emitter.states)-1]
+		return true
+	}
+	if !yaml_emitter_write_indent(emitter) {
+		return false
+	}
+	if !yaml_emitter_write_indicator(emitter, []byte{'-'}, true, false, true) {
+		return false
+	}
+	emitter.states = append(emitter.states, yaml_EMIT_INNER_FLOW_SEQUENCE_ITEM_STATE)
+	return yaml_emitter_emit_node(emitter, event, false, true, false, false)
+}
+
 // Expect a flow key node.
 func yaml_emitter_emit_flow_mapping_key(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
 	if first {
@@ -711,8 +741,10 @@ func yaml_emitter_emit_sequence_start(emitter *yaml_emitter_t, event *yaml_event
 	if !yaml_emitter_process_tag(emitter) {
 		return false
 	}
-	if emitter.flow_level > 0 || emitter.canonical || event.sequence_style() == yaml_FLOW_SEQUENCE_STYLE ||
-		yaml_emitter_check_empty_sequence(emitter) {
+	if event.sequence_style() == yaml_INNER_FLOW_SEQUENCE_STYLE {
+		emitter.state = yaml_EMIT_INNER_FLOW_SEQUENCE_FIRST_ITEM_STATE
+	} else if emitter.inner_flow_level > 0 || emitter.flow_level > 0 || emitter.canonical ||
+		event.sequence_style() == yaml_FLOW_SEQUENCE_STYLE || yaml_emitter_check_empty_sequence(emitter) {
 		emitter.state = yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE
 	} else {
 		emitter.state = yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"time"
 
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"net"
 	"os"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var marshalIntTest = 123
@@ -216,6 +217,14 @@ var marshalTests = []struct {
 			} "a,flow"
 		}{struct{ B, D string }{"c", "e"}},
 		"a: {b: c, d: e}\n",
+	},
+
+	// Inner flow flag
+	{
+		&struct {
+			A [][]int "a,innerflow"
+		}{[][]int{[]int{1, 2, 3}, []int{4, 5, 6}}},
+		"a:\n- [1, 2, 3]\n- [4, 5, 6]\n",
 	},
 
 	// Unexported field

--- a/yaml.go
+++ b/yaml.go
@@ -200,6 +200,7 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	InnerFlow bool
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -245,6 +246,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.OmitEmpty = true
 				case "flow":
 					info.Flow = true
+				case "innerflow":
+					info.InnerFlow = true
 				case "inline":
 					inline = true
 				default:

--- a/yamlh.go
+++ b/yamlh.go
@@ -88,8 +88,9 @@ const (
 	// Let the emitter choose the style.
 	yaml_ANY_SEQUENCE_STYLE yaml_sequence_style_t = iota
 
-	yaml_BLOCK_SEQUENCE_STYLE // The block sequence style.
-	yaml_FLOW_SEQUENCE_STYLE  // The flow sequence style.
+	yaml_BLOCK_SEQUENCE_STYLE      // The block sequence style.
+	yaml_FLOW_SEQUENCE_STYLE       // The flow sequence style.
+	yaml_INNER_FLOW_SEQUENCE_STYLE // The innerflow sequence style.
 )
 
 type yaml_mapping_style_t yaml_style_t
@@ -597,23 +598,25 @@ const (
 	// Expect STREAM-START.
 	yaml_EMIT_STREAM_START_STATE yaml_emitter_state_t = iota
 
-	yaml_EMIT_FIRST_DOCUMENT_START_STATE       // Expect the first DOCUMENT-START or STREAM-END.
-	yaml_EMIT_DOCUMENT_START_STATE             // Expect DOCUMENT-START or STREAM-END.
-	yaml_EMIT_DOCUMENT_CONTENT_STATE           // Expect the content of a document.
-	yaml_EMIT_DOCUMENT_END_STATE               // Expect DOCUMENT-END.
-	yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE   // Expect the first item of a flow sequence.
-	yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE         // Expect an item of a flow sequence.
-	yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE     // Expect the first key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_KEY_STATE           // Expect a key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE  // Expect a value for a simple key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_VALUE_STATE         // Expect a value of a flow mapping.
-	yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE  // Expect the first item of a block sequence.
-	yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE        // Expect an item of a block sequence.
-	yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE    // Expect the first key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_KEY_STATE          // Expect the key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE // Expect a value for a simple key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_VALUE_STATE        // Expect a value of a block mapping.
-	yaml_EMIT_END_STATE                        // Expect nothing.
+	yaml_EMIT_FIRST_DOCUMENT_START_STATE           // Expect the first DOCUMENT-START or STREAM-END.
+	yaml_EMIT_DOCUMENT_START_STATE                 // Expect DOCUMENT-START or STREAM-END.
+	yaml_EMIT_DOCUMENT_CONTENT_STATE               // Expect the content of a document.
+	yaml_EMIT_DOCUMENT_END_STATE                   // Expect DOCUMENT-END.
+	yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE       // Expect the first item of a flow sequence.
+	yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE             // Expect an item of a flow sequence.
+	yaml_EMIT_INNER_FLOW_SEQUENCE_FIRST_ITEM_STATE // Expect the first item of an inner flow sequence.
+	yaml_EMIT_INNER_FLOW_SEQUENCE_ITEM_STATE       // Expect an item of an inner flow sequence.
+	yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE         // Expect the first key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_KEY_STATE               // Expect a key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE      // Expect a value for a simple key of a flow mapping.
+	yaml_EMIT_FLOW_MAPPING_VALUE_STATE             // Expect a value of a flow mapping.
+	yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE      // Expect the first item of a block sequence.
+	yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE            // Expect an item of a block sequence.
+	yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE        // Expect the first key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_KEY_STATE              // Expect the key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE     // Expect a value for a simple key of a block mapping.
+	yaml_EMIT_BLOCK_MAPPING_VALUE_STATE            // Expect a value of a block mapping.
+	yaml_EMIT_END_STATE                            // Expect nothing.
 )
 
 // The emitter structure.
@@ -662,7 +665,8 @@ type yaml_emitter_t struct {
 
 	indent int // The current indentation level.
 
-	flow_level int // The current flow level.
+	flow_level       int // The current flow level.
+	inner_flow_level int // The current outer level before flow level.
 
 	root_context       bool // Is it the document root context?
 	sequence_context   bool // Is it a sequence context?


### PR DESCRIPTION
Allows a structure like this:
```go
type A struct {
  B [][]string `yaml:",innerflow"`
}
```
To create content like this:
```yaml
b:
- [/usr/bin/bash, install.sh]
- [systemctl, start, myservice]
```