### PR TITLE
Support usage of "~" to indicate null values for pointer types

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -251,7 +251,7 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "" && n.implicit) {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "~" || n.value == "" && n.implicit) {
 		return out, false, false
 	}
 	again := true

--- a/decode_test.go
+++ b/decode_test.go
@@ -440,9 +440,24 @@ var unmarshalTests = []struct {
 		map[string]*string{"foo": new(string)},
 	}, {
 		"foo: null",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: null",
 		map[string]string{"foo": ""},
 	}, {
 		"foo: null",
+		map[string]interface{}{"foo": nil},
+	},
+
+	// Support for ~
+	{
+		"foo: ~",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: ~",
+		map[string]string{"foo": ""},
+	}, {
+		"foo: ~",
 		map[string]interface{}{"foo": nil},
 	},
 


### PR DESCRIPTION
This is an implementation of the fix described in #265, and resolves #109 as well.