### PR TITLE
Add support for alternative timestamp formats

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -484,6 +484,11 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 			out.SetFloat(resolved)
 			good = true
 		}
+	case reflect.Struct:
+		if out.Type() == reflect.TypeOf(resolved) {
+			out.Set(reflect.ValueOf(resolved))
+			good = true
+		}
 	case reflect.Ptr:
 		if out.Type().Elem() == reflect.TypeOf(resolved) {
 			// TODO DOes this make sense? When is out a Ptr except when decoding a nil value?

--- a/decode.go
+++ b/decode.go
@@ -485,8 +485,8 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 			good = true
 		}
 	case reflect.Struct:
-		if out.Type() == reflect.TypeOf(resolved) {
-			out.Set(reflect.ValueOf(resolved))
+		if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
+			out.Set(resolvedv)
 			good = true
 		}
 	case reflect.Ptr:

--- a/decode_test.go
+++ b/decode_test.go
@@ -582,6 +582,18 @@ var unmarshalTests = []struct {
 		"a: 2015-02-24T18:19:39Z\n",
 		map[string]time.Time{"a": time.Unix(1424801979, 0).In(time.UTC)},
 	},
+	{
+		"a: 2015-01-01",
+		map[string]time.Time{"a": time.Unix(1420070400, 0)},
+	},
+	{
+		"a: !!str 2015-01-01",
+		map[string]string{"a": "2015-01-01"},
+	},
+	{
+		"a: \"2015-01-01\"",
+		map[string]interface{}{"a": "2015-01-01"},
+	},
 
 	// Encode empty lists as zero-length slices.
 	{

--- a/decode_test.go
+++ b/decode_test.go
@@ -580,17 +580,64 @@ var unmarshalTests = []struct {
 	},
 	{
 		"a: 2015-02-24T18:19:39Z\n",
-		map[string]time.Time{"a": time.Unix(1424801979, 0).In(time.UTC)},
+		map[string]time.Time{"a": time.Date(2015, 2, 24, 18, 19, 39, 0, time.UTC)},
+	},
+
+	// Timestamps
+	{
+		// Date only.
+		"a: 2015-01-01\n",
+		map[string]interface{}{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
 	},
 	{
-		"a: 2015-01-01",
-		map[string]time.Time{"a": time.Unix(1420070400, 0)},
+		// RFC3339
+		"a: 2015-02-24T18:19:39.12Z\n",
+		map[string]interface{}{"a": time.Date(2015, 2, 24, 18, 19, 39, .12e9, time.UTC)},
 	},
 	{
+		// RFC3339 with short dates.
+		"a: 2015-2-3T3:4:5Z",
+		map[string]interface{}{"a": time.Date(2015, 2, 3, 3, 4, 5, 0, time.UTC)},
+	},
+	{
+		// ISO8601 lower case t
+		"a: 2015-02-24t18:19:39Z\n",
+		map[string]interface{}{"a": time.Date(2015, 2, 24, 18, 19, 39, 0, time.UTC)},
+	},
+	{
+		// space separate, no time zone
+		"a: 2015-02-24 18:19:39\n",
+		map[string]interface{}{"a": time.Date(2015, 2, 24, 18, 19, 39, 0, time.UTC)},
+	},
+	// Some cases not currently handled. Uncomment these when
+	// the code is fixed.
+	//	{
+	//		// space separated with time zone
+	//		"a: 2001-12-14 21:59:43.10 -5",
+	//		map[string]interface{}{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
+	//	},
+	//	{
+	//		// arbitrary whitespace between fields
+	//		"a: 2001-12-14 \t\t \t21:59:43.10 \t Z",
+	//		map[string]interface{}{"a": time.Date(2001, 12, 14, 21, 59, 43, .1e9, time.UTC)},
+	//	},
+	{
+		// explicit string tag
 		"a: !!str 2015-01-01",
-		map[string]string{"a": "2015-01-01"},
+		map[string]interface{}{"a": "2015-01-01"},
 	},
 	{
+		// explicit timestamp tag on quoted string
+		"a: !!timestamp \"2015-01-01\"",
+		map[string]interface{}{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
+	},
+	{
+		// explicit timestamp tag on unquoted string
+		"a: !!timestamp 2015-01-01",
+		map[string]interface{}{"a": time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)},
+	},
+	{
+		// quoted string that's a valid timestamp
 		"a: \"2015-01-01\"",
 		map[string]interface{}{"a": "2015-01-01"},
 	},

--- a/encode.go
+++ b/encode.go
@@ -251,11 +251,17 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 			failf("cannot marshal invalid UTF-8 data as %s", shortTag(tag))
 		}
 	}
-	if tag == "" && (rtag != yaml_STR_TAG || isBase60Float(s)) {
+	switch {
+	case rtag == yaml_TIMESTAMP_TAG:
+		// TODO with the current code, there's no way for tag to be non-empty,
+		// but what should this function do if (for example) tag is yaml_BOOL_TAG
+		// and rtag is something incompatible with it?
+		style = yaml_PLAIN_SCALAR_STYLE
+	case tag == "" && (rtag != yaml_STR_TAG || isBase60Float(s)):
 		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
-	} else if strings.Contains(s, "\n") {
+	case strings.Contains(s, "\n"):
 		style = yaml_LITERAL_SCALAR_STYLE
-	} else {
+	default:
 		style = yaml_PLAIN_SCALAR_STYLE
 	}
 	e.emitScalar(s, "", tag, style)

--- a/encode_test.go
+++ b/encode_test.go
@@ -303,7 +303,7 @@ var marshalTests = []struct {
 		"a: 1.2.3.4\n",
 	},
 	{
-		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+		map[string]time.Time{"a": time.Date(2015, 2, 24, 18, 19, 39, 0, time.UTC)},
 		"a: 2015-02-24T18:19:39Z\n",
 	},
 
@@ -327,7 +327,8 @@ var marshalTests = []struct {
 func (s *S) TestMarshal(c *C) {
 	defer os.Setenv("TZ", os.Getenv("TZ"))
 	os.Setenv("TZ", "UTC")
-	for _, item := range marshalTests {
+	for i, item := range marshalTests {
+		c.Logf("test %d: %q", i, item.data)
 		data, err := yaml.Marshal(item.value)
 		c.Assert(err, IsNil)
 		c.Assert(string(data), Equals, item.data)


### PR DESCRIPTION
[This is a duplicate of #273 but applied against the devel branch]

yaml.org describes several alternative formats for timestamps not
covered by the default implementation of time.UnmarshalText(). A subset
of these is covered by this PR - future work can enable full
support for all formats.

Timestamps will only be collected if there is an explicit timestamp
tag (ie, not !!str) or if implicit type detection is enabled.

This PR builds on @anthonybishopric's foundations
(see PR #117).