### PR TITLE
quote "<<" keys on output

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -234,6 +234,7 @@ var (
 	ifaceType      = defaultMapType.Elem()
 	timeType       = reflect.TypeOf(time.Time{})
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
+	mergeTagType   = reflect.TypeOf(MergeTag)
 )
 
 func newDecoder(strict bool) *decoder {
@@ -760,5 +761,11 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 }
 
 func isMerge(n *node) bool {
-	return n.kind == scalarNode && n.value == "<<" && (n.implicit == true || n.tag == yaml_MERGE_TAG)
+	// Quick test so we avoid the overhead of calling resolve
+	// unless we're pretty sure it can be a merge node.
+	if n.kind != scalarNode || n.value != "<<" {
+		return false
+	}
+	_, v := resolve(n.tag, n.value)
+	return v == MergeTag
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -412,6 +412,11 @@ var unmarshalTests = []struct {
 		"v: ! test",
 		map[string]interface{}{"v": "test"},
 	},
+	// Non-specific tag with resolvable item.
+	{
+		"v: ! 99",
+		map[string]interface{}{"v": "99"},
+	},
 
 	// Anchors and aliases.
 	{
@@ -1080,6 +1085,7 @@ inlineSequenceMap:
   # Inlined map in sequence
   << : [ *CENTER, {"r": 10} ]
   label: center/big
+
 `
 
 func (s *S) TestMerge(c *C) {

--- a/encode.go
+++ b/encode.go
@@ -126,9 +126,12 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 			e.marshal(tag, in.Elem())
 		}
 	case reflect.Struct:
-		if in.Type() == timeType {
+		switch in.Type() {
+		case timeType:
 			e.timev(tag, in)
-		} else {
+		case mergeTagType:
+			e.mergeTagv(tag)
+		default:
 			e.structv(tag, in)
 		}
 	case reflect.Slice:
@@ -332,6 +335,10 @@ func (e *encoder) timev(tag string, in reflect.Value) {
 		tag = yaml_TIMESTAMP_TAG
 	}
 	e.emitScalar(t.Format(time.RFC3339Nano), "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
+func (e *encoder) mergeTagv(tag string) {
+	e.emitScalar("<<", "", tag, yaml_PLAIN_SCALAR_STYLE)
 }
 
 func (e *encoder) floatv(tag string, in reflect.Value) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -356,6 +356,17 @@ var marshalTests = []struct {
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
 	},
+
+	// << should be quoted so that it's not treated as a merge key.
+	{
+		map[string]string{"<<": "x"},
+		"\"<<\": x\n",
+	},
+	// Explicit merge tag key is left unquoted.
+	{
+		map[interface{}]interface{}{yaml.MergeTag: map[string]string{"a": "b"}},
+		"<<:\n  a: b\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {


### PR DESCRIPTION
This goes some way to fixing issue #245 - at least
the round trip behaviour will work OK now,
although it's still not possible to read externally-created
YAML which uses << as a map key.

Technically this could be considered an API-breaking change,
because existing code might be relying on the fact that << is not
quoted on output. To enable any such users to work around the
new behaviour (which I'm pretty sure is correct), we introduce a new
MergeTag value which can be used to produce an unquoted merge tag
value.