### PR TITLE
use 64 bit precision when formatting float values

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -336,8 +336,7 @@ func (e *encoder) timev(tag string, in reflect.Value) {
 }
 
 func (e *encoder) floatv(tag string, in reflect.Value) {
-	// FIXME: Handle 64 bits here.
-	s := strconv.FormatFloat(float64(in.Float()), 'g', -1, 32)
+	s := strconv.FormatFloat(in.Float(), 'g', -1, 64)
 	switch s {
 	case "+Inf":
 		s = ".inf"


### PR DESCRIPTION
It seems that the use of 32 bits here was an oversight.
