### PR TITLE
Decode into structs provided at runtime

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -711,6 +711,9 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			} else {
 				field = out.FieldByIndex(info.Inline)
 			}
+			if field.Kind() == reflect.Interface && field.Elem().Kind() == reflect.Ptr {
+				field = field.Elem()
+			}
 			d.unmarshal(n.children[i+1], field)
 		} else if sinfo.InlineMap != -1 {
 			if inlineMap.IsNil() {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1242,6 +1242,26 @@ func (t *textUnmarshaler) UnmarshalText(s []byte) error {
 	return nil
 }
 
+func (s *S) TestDynamic(c *C) {
+	type Parent struct {
+		Child interface{} `yaml:"child"`
+	}
+
+	type ChildStruct struct {
+		Foo int `yaml:"foo"`
+	}
+
+	data := []byte("child:\n  foo: 42")
+
+	out := Parent{Child: &ChildStruct{}}
+	yaml.Unmarshal([]byte(data), &out)
+
+	c.Assert(out, DeepEquals, Parent{Child: &ChildStruct{Foo: 42}})
+	if _, ok := out.Child.(*ChildStruct); !ok {
+		c.Fail()
+	}
+}
+
 //var data []byte
 //func init() {
 //	var err error


### PR DESCRIPTION
The current version creates new maps when asked to decode into `interface{}` values. Example:

```
package main

import (
	"fmt"

	"gopkg.in/yaml.v2"
)

type Parent struct {
	Child interface{} `yaml:"child"`
}

type ChildStruct struct {
	Foo int `yaml:"foo"`
}

func main() {
	var data = `
---
child:
  foo: 42
`

	out := Parent{Child: &ChildStruct{}}
	yaml.Unmarshal([]byte(data), &out)

	fmt.Printf("Out: %+v\n", out)
	fmt.Printf("Child: type: %T, value: %+v\n", out.Child, out.Child)

	// expected:
	// Out: {Child:0xc4200142f0}
	// Child: type: *main.ChildStruct, value: &{Foo:42}

	// current:
	// Out: {Child:map[foo:42]}
	// Child: type: map[interface {}]interface {}, value: map[foo:42]
}
```

This PR changes the decoder to use the provided struct pointed to by the interface. This matches the behavior of `encoding/json`.
  