### PR TITLE
Increment non-zero scanner error lines

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -81,6 +81,10 @@ func (p *parser) fail() {
 	var line int
 	if p.parser.problem_mark.line != 0 {
 		line = p.parser.problem_mark.line
+		// Scanner errors don't iterate line before returning error
+		if p.parser.error == yaml_SCANNER_ERROR {
+			line++
+		}
 	} else if p.parser.context_mark.line != 0 {
 		line = p.parser.context_mark.line
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -664,6 +664,8 @@ var unmarshalErrorTests = []struct {
 	{"v: !!float 'error'", "yaml: cannot decode !!str `error` as a !!float"},
 	{"v: [A,", "yaml: line 1: did not find expected node content"},
 	{"v:\n- [A,", "yaml: line 2: did not find expected node content"},
+	{"a:\n- b: *,", "yaml: line 2: did not find expected alphabetic or numeric character"},
+	{"a:\n- {b: c, d:e},", "yaml: line 2: found unexpected ':'"},
 	{"a: *b\n", "yaml: unknown anchor 'b' referenced"},
 	{"a: &a\n  b: *a\n", "yaml: anchor 'a' value contains itself"},
 	{"value: -", "yaml: block sequence entries are not allowed in this context"},


### PR DESCRIPTION
Scanner errors are 0 indexed. Errors occuring on lines greater than 0, referenced the previous line in the error text.

Fixes #205