### PR TITLE
Add a test for merges into MapSlice

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2,13 +2,14 @@ package yaml_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123
@@ -1000,6 +1001,29 @@ func (s *S) TestUnmarshalStrict(c *C) {
 	c.Check(err, IsNil)
 	err = yaml.UnmarshalStrict([]byte("a: 1\nb: 2\nc: 3"), &v)
 	c.Check(err, ErrorMatches, "yaml: unmarshal errors:\n  line 3: field c not found in struct struct { A int; B int }")
+}
+
+//It is interesting for users to have an alias to define custom interface methods
+type TestCustomMapSlice yaml.MapSlice
+
+func (s *S) TestMergeCustomMapSlice(c *C) {
+	container := TestCustomMapSlice{}
+	err := yaml.Unmarshal([]byte(mergeTests), &container)
+	c.Check(err, IsNil)
+
+	var want = TestCustomMapSlice{
+		yaml.MapItem{Key: "x", Value: 1},
+		yaml.MapItem{Key: "y", Value: 2},
+		yaml.MapItem{Key: "r", Value: 10},
+		yaml.MapItem{Key: "label", Value: "center/big"},
+	}
+
+	for _, test := range container {
+		if test.Key == "anchors" {
+			continue
+		}
+		c.Assert(test.Value, DeepEquals, want, Commentf("test %q failed", test))
+	}
 }
 
 //var data []byte


### PR DESCRIPTION
At the moment unmarshaling merges into MapSlice is broken.

This test won't pass for now, but should when the bug is resolved.