### PR TITLE
Fix and test merges with MapSlice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+debug.test

--- a/decode.go
+++ b/decode.go
@@ -647,11 +647,21 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 	mapType := d.mapType
 	d.mapType = outt
 
-	var slice []MapItem
-	var l = len(n.children)
-	for i := 0; i < l; i += 2 {
+	var keys []interface{}
+	kv := make(map[interface{}]interface{})
+
+	for i := 0; i < len(n.children); i += 2 {
 		if isMerge(n.children[i]) {
 			d.merge(n.children[i+1], out)
+			for i := 0; i < out.Len(); i++ {
+				item := out.Index(i).Interface().(MapItem)
+				_, ok := kv[item.Key]
+				kv[item.Key] = item.Value
+				if !ok {
+					keys = append(keys, item.Key)
+				}
+			}
+
 			continue
 		}
 		item := MapItem{}
@@ -659,11 +669,19 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 		if d.unmarshal(n.children[i], k) {
 			v := reflect.ValueOf(&item.Value).Elem()
 			if d.unmarshal(n.children[i+1], v) {
-				slice = append(slice, item)
+				_, ok := kv[item.Key]
+				kv[item.Key] = item.Value
+				if !ok {
+					keys = append(keys, item.Key)
+				}
 			}
 		}
 	}
-	out.Set(reflect.ValueOf(slice))
+	var output []MapItem
+	for _, key := range keys {
+		output = append(output, MapItem{key, kv[key]})
+	}
+	out.Set(reflect.ValueOf(output))
 	d.mapType = mapType
 	return true
 }
@@ -741,6 +759,30 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		}
 		d.unmarshal(n, out)
 	case sequenceNode:
+		if out.Kind() == reflect.Slice {
+			kv := make(map[interface{}]interface{})
+			var keys []interface{}
+			for i := len(n.children) - 1; i >= 0; i-- {
+				d.unmarshal(n.children[i], out)
+				var subitems []interface{}
+				for j := 0; j < out.Len(); j++ {
+					item := out.Index(j).Interface().(MapItem)
+					_, ok := kv[item.Key]
+					kv[item.Key] = item.Value
+					if !ok {
+						subitems = append(subitems, item.Key)
+					}
+				}
+				keys = append(subitems, keys...)
+			}
+			var output []MapItem
+			for _, key := range keys {
+				output = append(output, MapItem{key, kv[key]})
+			}
+			out.Set(reflect.ValueOf(output))
+			return
+		}
+
 		// Step backwards as earlier nodes take precedence.
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
@@ -754,9 +796,11 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 			}
 			d.unmarshal(ni, out)
 		}
+
 	default:
 		failWantMap()
 	}
+
 }
 
 func isMerge(n *node) bool {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1242,6 +1242,29 @@ func (t *textUnmarshaler) UnmarshalText(s []byte) error {
 	return nil
 }
 
+//It is interesting for users to have an alias to implement custom interface methods
+type TestCustomMapSlice yaml.MapSlice
+
+func (s *S) TestMergeCustomMapSlice(c *C) {
+	container := TestCustomMapSlice{}
+	err := yaml.Unmarshal([]byte(mergeTests), &container)
+	c.Check(err, IsNil)
+
+	var want = TestCustomMapSlice{
+		yaml.MapItem{Key: "x", Value: 1},
+		yaml.MapItem{Key: "y", Value: 2},
+		yaml.MapItem{Key: "r", Value: 10},
+		yaml.MapItem{Key: "label", Value: "center/big"},
+	}
+
+	for _, test := range container {
+		if test.Key == "anchors" {
+			continue
+		}
+		c.Assert(test.Value, DeepEquals, want, Commentf("test %q failed", test))
+	}
+}
+
 //var data []byte
 //func init() {
 //	var err error

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,8 +1,9 @@
 package yaml_test
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
This patch adds tests and working code when decoding merges into `MapSlice`.