### PR TITLE
Handle custom tags

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -94,6 +94,17 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		// we don't want to treat it as a string for YAML
 		// purposes because YAML has special support for
 		// timestamps.
+	case TagMarshaler:
+		v, newtag, err := m.MarshalYAMLWithTag()
+		if err != nil {
+			fail(err)
+		}
+		if v == nil {
+			e.nilv()
+			return
+		}
+		in = reflect.ValueOf(v)
+		tag = newtag
 	case Marshaler:
 		v, err := m.MarshalYAML()
 		if err != nil {

--- a/resolve.go
+++ b/resolve.go
@@ -89,6 +89,30 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
+func isScalarTag(tag string) bool {
+	switch tag {
+	case yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG, yaml_TIMESTAMP_TAG, yaml_BINARY_TAG:
+		return true
+	}
+	return false
+}
+
+func isMappingTag(tag string) bool {
+	return tag == yaml_MAP_TAG
+}
+
+func isSequenceTag(tag string) bool {
+	return tag == yaml_SEQ_TAG
+}
+
+func isBuiltinTag(tag string) bool {
+	return isMappingTag(tag) || isSequenceTag(tag) || isScalarTag(tag) || tag == yaml_MERGE_TAG
+}
+
+func isCustomTag(tag string) bool {
+	return tag != "" && !isBuiltinTag(tag)
+}
+
 var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {


### PR DESCRIPTION
See also https://github.com/go-yaml/yaml/issues/191 and https://github.com/go-yaml/yaml/pull/204

This handles the basic case of 'I want tag information', but doesn't allow one to register custom unmarshalers (yet) outside of that enabled by UnmarshalYAMLWithTag (see addition to yaml.go). However, it seems like this will cover a bunch of use cases, and means that data isn't lost on marshaling/unmarshaling custom tags.

I've also snuck in a backwards incompatible change: validating the existing yaml types.

I'm interested in feedback on the approach. A bunch of tests need to be added, and will be if this is likely to be merged.