### PR TITLE
Fix implicit tag resolution

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -25,6 +25,12 @@ var unmarshalTests = []struct {
 	{
 		"{}", &struct{}{},
 	}, {
+		"leading zero: 08765",
+		map[string]string{"leading zero": "08765"},
+	}, {
+		"leading zero: 08765",
+		map[string]interface{}{"leading zero": "08765"},
+	}, {
 		"v: hi",
 		map[string]string{"v": "hi"},
 	}, {
@@ -129,6 +135,9 @@ var unmarshalTests = []struct {
 	}, {
 		"bin: -0b101010",
 		map[string]interface{}{"bin": -42},
+	}, {
+		"bin: +0b101010",
+		map[string]interface{}{"bin": 42},
 	}, {
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
 		map[string]interface{}{"bin": -9223372036854775808},

--- a/encode_test.go
+++ b/encode_test.go
@@ -31,6 +31,12 @@ var marshalTests = []struct {
 		&struct{}{},
 		"{}\n",
 	}, {
+		map[string]string{"leading zero": "08765"},
+		"leading zero: 08765\n",
+	}, {
+		map[string]interface{}{"leading zero": "08765"},
+		"leading zero: 08765\n",
+	}, {
 		map[string]string{"v": "hi"},
 		"v: hi\n",
 	}, {

--- a/yamlh.go
+++ b/yamlh.go
@@ -520,8 +520,8 @@ type yaml_alias_data_t struct {
 
 // The parser structure.
 //
-// All members are internal. Manage the structure using the
-// yaml_parser_ family of functions.
+// All members are internal. Manage the structure using the @c yaml_parser_
+// family of functions.
 type yaml_parser_t struct {
 
 	// Error handling


### PR DESCRIPTION
1) According to [spec](http://yaml.org/type/int.html), a value with leading zero is valid only if it's base 8 otherwise it's not an integer, this is confirmed by Regexp:
 ```
 [-+]?0b[0-1_]+ # (base 2)
|[-+]?0[0-7_]+ # (base 8)
|[-+]?(0|[1-9][0-9_]*) # (base 10)
|[-+]?0x[0-9a-fA-F_]+ # (base 16)
|[-+]?[1-9][0-9_]*(:[0-5]?[0-9])+ # (base 60)
```
I suppose we should leave such values as strings and thus we shouldn't quote them in an encoder.

2) I added support binary with '+' sign.

3) I made yamlStyleFloat more strict, now it validates input before parsing it but I still treat very big int as float.

4) Fixed always true condition: `true || intv == int64(int(intv))`.