### PR TITLE
Allow the DefaultMapType to be overridden

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -232,16 +232,17 @@ type decoder struct {
 }
 
 var (
-	mapItemType    = reflect.TypeOf(MapItem{})
-	durationType   = reflect.TypeOf(time.Duration(0))
-	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
-	ifaceType      = defaultMapType.Elem()
+	mapItemType  = reflect.TypeOf(MapItem{})
+	durationType = reflect.TypeOf(time.Duration(0))
+	// DefaultMapType type to unmarshal maps into, use MapSlice for ordered maps.
+	DefaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	ifaceType      = DefaultMapType.Elem()
 	timeType       = reflect.TypeOf(time.Time{})
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )
 
 func newDecoder(strict bool) *decoder {
-	d := &decoder{mapType: defaultMapType, strict: strict}
+	d := &decoder{mapType: DefaultMapType, strict: strict}
 	d.aliases = make(map[*node]bool)
 	return d
 }


### PR DESCRIPTION
I'm using this library to decode arbitrary Yaml, perform a transform then output the results (see http://github.com/mikefarah/yq).

The issue I have is that I don't know the root type of the yaml before hand, but I would like to preserve the order of the Map keys if it is a Map (using MapSlice).

This change allows me to override the defaultMapType to MapSlice to that effect.
```
yaml.DefaultMapType = reflect.TypeOf(yaml.MapSlice{})
```

Thoughts?