### PR TITLE
Add a decoder option to limit the number of unmarshalled values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -224,11 +224,13 @@ func (p *parser) mapping() *node {
 // Decoder, unmarshals a node into a provided value.
 
 type decoder struct {
-	doc     *node
-	aliases map[*node]bool
-	mapType reflect.Type
-	terrors []string
-	strict  bool
+	doc           *node
+	aliases       map[*node]bool
+	mapType       reflect.Type
+	terrors       []string
+	strict        bool
+	maxValues     int
+	decodedValues int
 }
 
 var (
@@ -334,6 +336,11 @@ func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 		good = d.sequence(n, out)
 	default:
 		panic("internal error: unknown node kind: " + strconv.Itoa(n.kind))
+	}
+	d.decodedValues++
+	if d.maxValues != 0 && d.decodedValues > d.maxValues {
+		good = false
+		failf("exceeded max number of decoded values (%d)", d.maxValues)
 	}
 	return good
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1339,12 +1339,12 @@ g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
 h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
 i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]`
 	var v map[string]interface{}
-	d := yaml.NewDecoder(bytes.NewBuffer([]byte(bombCase)), yaml.WithLimitDecodedValuesCount(100000))
+	d := yaml.NewDecoder(bytes.NewBuffer([]byte(bombCase)), yaml.WithLimitDecodedValuesCount(1000000))
 	err := d.Decode(&v)
-	c.Assert(err, ErrorMatches, `yaml: exceeded max number of decoded values \(100000\)`)
+	c.Assert(err, ErrorMatches, `yaml: exceeded max number of decoded values \(1000000\)`)
 	ordinalCase := `hello: world`
 	d = yaml.NewDecoder(bytes.NewBuffer([]byte(ordinalCase)), yaml.WithLimitDecodedValuesCount(3))
 	// decoded values are [Hello, World, [Hello:World pair]]
 	err = d.Decode(&v)
-	c.Assert(err, Equals, nil)
+	c.Assert(err, IsNil)
 }

--- a/yaml.go
+++ b/yaml.go
@@ -89,26 +89,45 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
+// DecoderOption is an option to apply to modyfy a decoder's behavior
+type DecoderOption func(d *decoder)
+
+// WithStrict is a decoder option specifying if decoding should be strict
+func WithStrict(strict bool) DecoderOption {
+	return func(d *decoder) {
+		d.strict = strict
+	}
+}
+
+// WithLimitDecodedValuesCount limits the number of values decoded
+// This is usefull when parsing potentially malicious documents
+func WithLimitDecodedValuesCount(maxValues int) DecoderOption {
+	return func(d *decoder) {
+		d.maxValues = maxValues
+	}
+}
+
 // A Decorder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	strict bool
-	parser *parser
+	options []DecoderOption
+	parser  *parser
 }
 
 // NewDecoder returns a new decoder that reads from r.
 //
 // The decoder introduces its own buffering and may read
 // data from r beyond the YAML values requested.
-func NewDecoder(r io.Reader) *Decoder {
+func NewDecoder(r io.Reader, opts ...DecoderOption) *Decoder {
 	return &Decoder{
-		parser: newParserFromReader(r),
+		parser:  newParserFromReader(r),
+		options: opts,
 	}
 }
 
 // SetStrict sets whether strict decoding behaviour is enabled when
 // decoding items in the data (see UnmarshalStrict). By default, decoding is not strict.
 func (dec *Decoder) SetStrict(strict bool) {
-	dec.strict = strict
+	dec.options = append(dec.options, WithStrict(strict))
 }
 
 // Decode reads the next YAML-encoded value from its input
@@ -117,7 +136,10 @@ func (dec *Decoder) SetStrict(strict bool) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (dec *Decoder) Decode(v interface{}) (err error) {
-	d := newDecoder(dec.strict)
+	d := newDecoder(false)
+	for _, o := range dec.options {
+		o(d)
+	}
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {

--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
-// DecoderOption is an option to apply to modyfy a decoder's behavior
+// DecoderOption is an option to apply to modify a decoder's behavior
 type DecoderOption func(d *decoder)
 
 // WithStrict is a decoder option specifying if decoding should be strict


### PR DESCRIPTION
This PR gives user code the opportunity to limit the number of values unmarshalled while decoding a yaml payload.

This is very usefull to protect programs from malicious external yaml documents such as these:
```
version: "3" 
services: &services ["lol","lol","lol","lol","lol","lol","lol","lol","lol"] 
b: &b [*services,*services,*services,*services,*services,*services,*services,*services,*services] 
c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b] 
d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c] 
e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d] 
f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e] 
g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f] 
h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g] 
i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
```
This is a valid document, but parsing this will crash the program with an out of memory panic at some point.
