### PR TITLE
Allow specifying flow or block style at encode time

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -17,6 +17,7 @@ type encoder struct {
 	emitter yaml_emitter_t
 	event   yaml_event_t
 	out     []byte
+	style   EncodingStyle
 	flow    bool
 	// doneInit holds whether the initial stream_start_event has been
 	// emitted.
@@ -194,7 +195,9 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 				continue
 			}
 			e.marshal("", reflect.ValueOf(info.Key))
-			e.flow = info.Flow
+			if e.style == DefaultStyle {
+				e.flow = info.Flow
+			}
 			e.marshal("", value)
 		}
 		if sinfo.InlineMap >= 0 {
@@ -219,7 +222,7 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 func (e *encoder) mappingv(tag string, f func()) {
 	implicit := tag == ""
 	style := yaml_BLOCK_MAPPING_STYLE
-	if e.flow {
+	if e.flow || e.style == FlowStyle {
 		e.flow = false
 		style = yaml_FLOW_MAPPING_STYLE
 	}
@@ -233,7 +236,7 @@ func (e *encoder) mappingv(tag string, f func()) {
 func (e *encoder) slicev(tag string, in reflect.Value) {
 	implicit := tag == ""
 	style := yaml_BLOCK_SEQUENCE_STYLE
-	if e.flow {
+	if e.flow || e.style == FlowStyle {
 		e.flow = false
 		style = yaml_FLOW_SEQUENCE_STYLE
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -405,6 +405,44 @@ func (s *S) TestEncoderMultipleDocuments(c *C) {
 	c.Assert(buf.String(), Equals, "a: b\n---\nc: d\n")
 }
 
+func (s *S) TestEncoderForceFlow(c *C) {
+	v := struct {
+		A map[string]string "a"
+		B []int             "b,flow"
+	}{
+		A: map[string]string{"a1": "a1", "a2": "a2"},
+		B: []int{1, 2},
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.UseStyle(yaml.FlowStyle)
+	err := enc.Encode(v)
+	c.Assert(err, Equals, nil)
+	enc.UseStyle(yaml.BlockStyle)
+	err = enc.Encode(v)
+	c.Assert(err, Equals, nil)
+	enc.UseStyle(yaml.DefaultStyle)
+	err = enc.Encode(v)
+	c.Assert(err, Equals, nil)
+	err = enc.Close()
+	c.Assert(err, Equals, nil)
+	c.Assert(buf.String(), Equals, `{a: {a1: a1, a2: a2}, b: [1, 2]}
+---
+a:
+  a1: a1
+  a2: a2
+b:
+- 1
+- 2
+---
+a:
+  a1: a1
+  a2: a2
+b: [1, 2]
+`)
+}
+
 func (s *S) TestEncoderWriteError(c *C) {
 	enc := yaml.NewEncoder(errorWriter{})
 	err := enc.Encode(map[string]string{"a": "b"})

--- a/yaml.go
+++ b/yaml.go
@@ -241,6 +241,25 @@ func (e *Encoder) Close() (err error) {
 	return nil
 }
 
+// EncodingStyle represents a YAML encoding style.
+type EncodingStyle int
+
+const (
+	// DefaultStyle uses BlockStyle unless a struct tag requests flow style.
+	DefaultStyle EncodingStyle = iota
+
+	// BlockStyle uses indentation to separate values and indicate scope.
+	BlockStyle
+
+	// FlowStyle uses explicit indicators to separate values and indicate scope.
+	FlowStyle
+)
+
+// UseStyle uses the given EncodingStyle to encode values.
+func (e *Encoder) UseStyle(es EncodingStyle) {
+	e.encoder.style = es
+}
+
 func handleErr(err *error) {
 	if v := recover(); v != nil {
 		if e, ok := v.(yamlError); ok {


### PR DESCRIPTION
It is often useful to be able to encode a given value in both block and
flow style. The current struct tag-based API requires committing to
either block or flow style for a given field. It also provides no means
of requesting that the top-level struct use flow style.

Introduce a new API, Encoder.UseStyle, which requests that all encoded
values use a particular encoding style.