### PR TITLE
Allow Marshal / UnMarshal of reflect.Value objects

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -142,6 +142,9 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	node := p.parse()
 	if node != nil {
 		v := reflect.ValueOf(out)
+		if vOut, ok := out.(reflect.Value); ok {
+			v = vOut
+		}
 		if v.Kind() == reflect.Ptr && !v.IsNil() {
 			v = v.Elem()
 		}
@@ -200,7 +203,11 @@ func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
 	defer e.destroy()
-	e.marshalDoc("", reflect.ValueOf(in))
+	v := reflect.ValueOf(in)
+	if vIn, ok := in.(reflect.Value); ok {
+		v = vIn
+	}
+	e.marshalDoc("", v)
 	e.finish()
 	out = e.out
 	return


### PR DESCRIPTION
this change solves the problem of having a reflect.Value that you wish to send to unmarshal/marshal and get meaningful / expected behavior for advanced usage cases.

it makes it super clean and avoids needing to send an empty interface and parsing the resulting map[interface{}]interface{} as it directly sets against the reflect.value passed in.

i am happy to explain my use case in detail for wanting this change if desired.