### PR TITLE
Update tested golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: go
 
 go:
-    - 1.4
-    - 1.5
-    - 1.6
-    - 1.7
-    - 1.8
-    - 1.9
-    - tip
+- 1.4.x
+- 1.5.x
+- 1.6.x
+- 1.7.x
+- 1.8.x
+- 1.9.x
+- 1.10.x
+- 1.11.x
+- master
 
 go_import_path: gopkg.in/yaml.v2


### PR DESCRIPTION
using (recently added) version alias support and `master` instead of legacy `tip` alias.