### PR TITLE
Able to skip exported fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Example
 package main
 
 import (
-        "fmt"
-        "log"
+	"fmt"
+	"log"
 
-        "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var data = `
@@ -63,46 +63,48 @@ a: Easy!
 b:
   c: 2
   d: [3, 4]
+  E: skippedInStruct
 `
 
 // Note: struct fields must be public in order for unmarshal to
 // correctly populate the data.
 type T struct {
-        A string
-        B struct {
-                RenamedC int   `yaml:"c"`
-                D        []int `yaml:",flow"`
-        }
+	A string
+	B struct {
+		RenamedC int    `yaml:"c"`
+		D        []int  `yaml:",flow"`
+		SkipE    string `yaml:",skip"`
+	}
 }
 
 func main() {
-        t := T{}
-    
-        err := yaml.Unmarshal([]byte(data), &t)
-        if err != nil {
-                log.Fatalf("error: %v", err)
-        }
-        fmt.Printf("--- t:\n%v\n\n", t)
-    
-        d, err := yaml.Marshal(&t)
-        if err != nil {
-                log.Fatalf("error: %v", err)
-        }
-        fmt.Printf("--- t dump:\n%s\n\n", string(d))
-    
-        m := make(map[interface{}]interface{})
-    
-        err = yaml.Unmarshal([]byte(data), &m)
-        if err != nil {
-                log.Fatalf("error: %v", err)
-        }
-        fmt.Printf("--- m:\n%v\n\n", m)
-    
-        d, err = yaml.Marshal(&m)
-        if err != nil {
-                log.Fatalf("error: %v", err)
-        }
-        fmt.Printf("--- m dump:\n%s\n\n", string(d))
+	t := T{}
+
+	err := yaml.Unmarshal([]byte(data), &t)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	fmt.Printf("--- t:\n%v\n\n", t)
+
+	d, err := yaml.Marshal(&t)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	fmt.Printf("--- t dump:\n%s\n\n", string(d))
+
+	m := make(map[interface{}]interface{})
+
+	err = yaml.Unmarshal([]byte(data), &m)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	fmt.Printf("--- m:\n%v\n\n", m)
+
+	d, err = yaml.Marshal(&m)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	fmt.Printf("--- m dump:\n%s\n\n", string(d))
 }
 ```
 
@@ -110,7 +112,7 @@ This example will generate the following output:
 
 ```
 --- t:
-{Easy! {2 [3 4]}}
+{Easy! {2 [3 4] }}
 
 --- t dump:
 a: Easy!
@@ -120,11 +122,12 @@ b:
 
 
 --- m:
-map[a:Easy! b:map[c:2 d:[3 4]]]
+map[b:map[d:[3 4] E:skippedInStruct c:2] a:Easy!]
 
 --- m dump:
 a: Easy!
 b:
+  E: skippedInStruct
   c: 2
   d:
   - 3

--- a/encode.go
+++ b/encode.go
@@ -190,7 +190,7 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 			} else {
 				value = in.FieldByIndex(info.Inline)
 			}
-			if info.OmitEmpty && isZero(value) {
+			if info.OmitEmpty && isZero(value) || info.Skip {
 				continue
 			}
 			e.marshal("", reflect.ValueOf(info.Key))

--- a/yaml.go
+++ b/yaml.go
@@ -296,6 +296,7 @@ type fieldInfo struct {
 	Num       int
 	OmitEmpty bool
 	Flow      bool
+	Skip      bool
 	// Id holds the unique field identifier, so we can cheaply
 	// check for field duplicates without maintaining an extra map.
 	Id int
@@ -346,6 +347,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.Flow = true
 				case "inline":
 					inline = true
+				case "skip":
+					info.Skip = true
 				default:
 					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
 				}


### PR DESCRIPTION
This PR makes `goyaml` able to skip exported fields in struct. To skip marshaling and unmarshaling exported fields, just add a `skip` tag in struct tags.