### PR TITLE
Add support for json.Number.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -714,6 +714,14 @@ var unmarshalTests = []struct {
 		"---\nhello\n...\n}not yaml",
 		"hello",
 	},
+	{
+		"a: 5\n",
+		&struct{ A jsonNumberT }{"5"},
+	},
+	{
+		"a: 5.5\n",
+		&struct{ A jsonNumberT }{"5.5"},
+	},
 }
 
 type M map[interface{}]interface{}

--- a/encode_test.go
+++ b/encode_test.go
@@ -15,6 +15,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type jsonNumberT string
+
+func (j jsonNumberT) Int64() (int64, error) {
+	val, err := strconv.Atoi(string(j))
+	if err != nil {
+		return 0, err
+	}
+	return int64(val), nil
+}
+
+func (j jsonNumberT) Float64() (float64, error) {
+	return strconv.ParseFloat(string(j), 64)
+}
+
+func (j jsonNumberT) String() string {
+	return string(j)
+}
+
 var marshalIntTest = 123
 
 var marshalTests = []struct {
@@ -366,6 +384,18 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("5")},
+		"a: 5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("100.5")},
+		"a: 100.5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("bogus")},
+		"a: bogus\n",
 	},
 }
 


### PR DESCRIPTION
This commit adds support for encoding json.Number as a number
instead of as a string, which is the underlying type of
json.Number.

Care has been taken to not introduce a dependency on the
encoding/json package, by using an interface that specifies the
methods of json.Number instead of the datatype itself. This also
means that other packages that use a similar datatype will be
supported. (Like json-iterator)

This is useful for tools that wish to convert JSON data into YAML
data by deserializing JSON into a map[string]interface{}, and use
the json.Encoder's UseNumber() method, or structs that use the
json.Number datatype and also wish to support yaml.