### PR TITLE
defaultMapType should be map[string]interface{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
         }
         fmt.Printf("--- t dump:\n%s\n\n", string(d))
     
-        m := make(map[interface{}]interface{})
+        m := make(map[string]interface{})
     
         err = yaml.Unmarshal([]byte(data), &m)
         if err != nil {

--- a/decode.go
+++ b/decode.go
@@ -234,7 +234,7 @@ type decoder struct {
 var (
 	mapItemType    = reflect.TypeOf(MapItem{})
 	durationType   = reflect.TypeOf(time.Duration(0))
-	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	defaultMapType = reflect.TypeOf(map[string]interface{}{})
 	ifaceType      = defaultMapType.Elem()
 	timeType       = reflect.TypeOf(time.Time{})
 	ptrTimeType    = reflect.TypeOf(&time.Time{})

--- a/decode_test.go
+++ b/decode_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moorara/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123
@@ -207,7 +207,7 @@ var unmarshalTests = []struct {
 	// Map inside interface with no type hints.
 	{
 		"a: {b: c}",
-		map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": "c"}},
+		map[string]interface{}{"a": map[string]interface{}{"b": "c"}},
 	},
 
 	// Structs and type conversions.
@@ -395,7 +395,7 @@ var unmarshalTests = []struct {
 	// Quoted values.
 	{
 		"'1': '\"2\"'",
-		map[interface{}]interface{}{"1": "\"2\""},
+		map[string]interface{}{"1": "\"2\""},
 	}, {
 		"v:\n- A\n- 'B\n\n  C'\n",
 		map[string][]string{"v": []string{"A", "B\nC"}},
@@ -527,7 +527,7 @@ var unmarshalTests = []struct {
 	// issue #295 (allow scalars with colons in flow mappings and sequences)
 	{
 		"a: {b: https://github.com/go-yaml/yaml}",
-		map[string]interface{}{"a": map[interface{}]interface{}{
+		map[string]interface{}{"a": map[string]interface{}{
 			"b": "https://github.com/go-yaml/yaml",
 		}},
 	},
@@ -575,7 +575,7 @@ var unmarshalTests = []struct {
 	// Issue #39.
 	{
 		"a:\n b:\n  c: d\n",
-		map[string]struct{ B interface{} }{"a": {map[interface{}]interface{}{"c": "d"}}},
+		map[string]struct{ B interface{} }{"a": {map[string]interface{}{"c": "d"}}},
 	},
 
 	// Custom map type.
@@ -702,7 +702,7 @@ var unmarshalTests = []struct {
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{
 		"First occurrence: &anchor Foo\nSecond occurrence: *anchor\nOverride anchor: &anchor Bar\nReuse anchor: *anchor\n",
-		map[interface{}]interface{}{
+		map[string]interface{}{
 			"Reuse anchor":      "Bar",
 			"First occurrence":  "Foo",
 			"Second occurrence": "Foo",
@@ -716,7 +716,7 @@ var unmarshalTests = []struct {
 	},
 }
 
-type M map[interface{}]interface{}
+type M map[string]interface{}
 
 type inlineB struct {
 	B       int
@@ -780,12 +780,12 @@ var decoderTests = []struct {
 }, {
 	"a: b",
 	[]interface{}{
-		map[interface{}]interface{}{"a": "b"},
+		map[string]interface{}{"a": "b"},
 	},
 }, {
 	"---\na: b\n...\n",
 	[]interface{}{
-		map[interface{}]interface{}{"a": "b"},
+		map[string]interface{}{"a": "b"},
 	},
 }, {
 	"---\n'hello'\n...\n---\ngoodbye\n...\n",
@@ -869,7 +869,7 @@ var unmarshalerTests = []struct {
 	data, tag string
 	value     interface{}
 }{
-	{"_: {hi: there}", "!!map", map[interface{}]interface{}{"hi": "there"}},
+	{"_: {hi: there}", "!!map", map[string]interface{}{"hi": "there"}},
 	{"_: [1,A]", "!!seq", []interface{}{1, "A"}},
 	{"_: 10", "!!int", 10},
 	{"_: null", "!!null", nil},
@@ -933,7 +933,7 @@ func (s *S) TestUnmarshalerWholeDocument(c *C) {
 	obj := &unmarshalerType{}
 	err := yaml.Unmarshal([]byte(unmarshalerTests[0].data), obj)
 	c.Assert(err, IsNil)
-	value, ok := obj.value.(map[interface{}]interface{})
+	value, ok := obj.value.(map[string]interface{})
 	c.Assert(ok, Equals, true, Commentf("value: %#v", obj.value))
 	c.Assert(value["_"], DeepEquals, unmarshalerTests[0].value)
 }
@@ -1108,14 +1108,14 @@ inlineSequenceMap:
 `
 
 func (s *S) TestMerge(c *C) {
-	var want = map[interface{}]interface{}{
+	var want = map[string]interface{}{
 		"x":     1,
 		"y":     2,
 		"r":     10,
 		"label": "center/big",
 	}
 
-	var m map[interface{}]interface{}
+	var m map[string]interface{}
 	err := yaml.Unmarshal([]byte(mergeTests), &m)
 	c.Assert(err, IsNil)
 	for name, test := range m {
@@ -1232,7 +1232,7 @@ var unmarshalStrictTests = []struct {
 	error: `yaml: unmarshal errors:\n  line 4: key "c" already set in map`,
 }, {
 	data: "a: 1\n9: 2\nnull: 3\n9: 4",
-	value: map[interface{}]interface{}{
+	value: map[string]interface{}{
 		"a": 1,
 		nil: 3,
 		9:   4,

--- a/encode_test.go
+++ b/encode_test.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/moorara/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 )
 
 var marshalIntTest = 123
@@ -106,7 +106,7 @@ var marshalTests = []struct {
 		map[string][]interface{}{"v": []interface{}{"A", 1, map[string][]int{"B": []int{2, 3}}}},
 		"v:\n- A\n- 1\n- B:\n  - 2\n  - 3\n",
 	}, {
-		map[string]interface{}{"a": map[interface{}]interface{}{"b": "c"}},
+		map[string]interface{}{"a": map[string]interface{}{"b": "c"}},
 		"a:\n  b: c\n",
 	}, {
 		map[string]interface{}{"a": "-"},
@@ -466,7 +466,7 @@ var marshalerTests = []struct {
 	data  string
 	value interface{}
 }{
-	{"_:\n  hi: there\n", map[interface{}]interface{}{"hi": "there"}},
+	{"_:\n  hi: there\n", map[string]interface{}{"hi": "there"}},
 	{"_:\n- 1\n- A\n", []interface{}{1, "A"}},
 	{"_: 10\n", 10},
 	{"_: null\n", nil},


### PR DESCRIPTION
I was hoping `go-yaml` is matching the behaviour of built-in `encoding/json`.
As a result, I think the `defaultMapType` should be `map[string]interface{}`.