### PR TITLE
Accept !!env tag in yaml file

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -380,6 +381,8 @@ func (d *decoder) scalar(n *node, out reflect.Value) bool {
 				failf("!!binary value contains invalid base64 data")
 			}
 			resolved = string(data)
+		} else if tag == yaml_ENV_TAG {
+			resolved = os.Getenv(resolved.(string))
 		}
 	}
 	if resolved == nil {
@@ -401,7 +404,7 @@ func (d *decoder) scalar(n *node, out reflect.Value) bool {
 		u, ok := out.Addr().Interface().(encoding.TextUnmarshaler)
 		if ok {
 			var text []byte
-			if tag == yaml_BINARY_TAG {
+			if tag == yaml_BINARY_TAG || tag == yaml_ENV_TAG {
 				text = []byte(resolved.(string))
 			} else {
 				// We let any value be unmarshaled into TextUnmarshaler.
@@ -418,7 +421,7 @@ func (d *decoder) scalar(n *node, out reflect.Value) bool {
 	}
 	switch out.Kind() {
 	case reflect.String:
-		if tag == yaml_BINARY_TAG {
+		if tag == yaml_BINARY_TAG || tag == yaml_ENV_TAG {
 			out.SetString(resolved.(string))
 			return true
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -566,6 +567,12 @@ var unmarshalTests = []struct {
 		map[string]string{"a": strings.Repeat("\x00", 52)},
 	},
 
+	// Env vars
+	{
+		"a: !!env TEST_ENV\n",
+		map[string]string{"a": "value_env"},
+	},
+
 	// Ordered maps.
 	{
 		"{b: 2, a: 1, d: 4, c: 3, sub: {e: 5}}",
@@ -736,6 +743,8 @@ type inlineC struct {
 }
 
 func (s *S) TestUnmarshal(c *C) {
+	defer os.Setenv("TEST_ENV", "")
+	os.Setenv("TEST_ENV", "value_env")
 	for i, item := range unmarshalTests {
 		c.Logf("test %d: %q", i, item.data)
 		t := reflect.ValueOf(item.value).Type()
@@ -763,6 +772,8 @@ func (s *S) TestUnmarshalFullTimestamp(c *C) {
 func (s *S) TestDecoderSingleDocument(c *C) {
 	// Test that Decoder.Decode works as expected on
 	// all the unmarshal tests.
+	defer os.Setenv("TEST_ENV", "")
+	os.Setenv("TEST_ENV", "value_env")
 	for i, item := range unmarshalTests {
 		c.Logf("test %d: %q", i, item.data)
 		if item.data == "" {

--- a/resolve.go
+++ b/resolve.go
@@ -90,7 +90,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 
 	defer func() {
 		switch tag {
-		case "", rtag, yaml_STR_TAG, yaml_BINARY_TAG:
+		case "", rtag, yaml_STR_TAG, yaml_BINARY_TAG, yaml_ENV_TAG:
 			return
 		case yaml_FLOAT_TAG:
 			if rtag == yaml_INT_TAG {
@@ -115,7 +115,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 	if in != "" {
 		hint = resolveTable[in[0]]
 	}
-	if hint != 0 && tag != yaml_STR_TAG && tag != yaml_BINARY_TAG {
+	if hint != 0 && tag != yaml_STR_TAG && tag != yaml_BINARY_TAG && tag != yaml_ENV_TAG {
 		// Handle things we can lookup in a map.
 		if item, ok := resolveMap[in]; ok {
 			return item.tag, item.value
@@ -180,7 +180,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
 				if err == nil {
 					if true || intv == int64(int(intv)) {
 						return yaml_INT_TAG, int(intv)

--- a/yamlh.go
+++ b/yamlh.go
@@ -319,6 +319,7 @@ const (
 	// Not in original libyaml.
 	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
 	yaml_MERGE_TAG  = "tag:yaml.org,2002:merge"
+	yaml_ENV_TAG    = "tag:yaml.org,2002:env"
 
 	yaml_DEFAULT_SCALAR_TAG   = yaml_STR_TAG // The default scalar tag is !!str.
 	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG // The default sequence tag is !!seq.


### PR DESCRIPTION
This commit adds support for a `!!env` tag, which can be used to load
a variable from an environment variable.

For example:

```
host: !!env HOSTNAME
```

will load the host value from the HOSTNAME environment variable.