### PR TITLE
resolve: add missing character in float regex

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -691,13 +691,13 @@ var unmarshalTests = []struct {
 		M{"ñoño": "very yes 🟔"},
 	},
 
-	// YAML Float regex shouldn't match this
+	// YAML Float regex
 	{
 		"a: 123456e1\n",
-		M{"a": "123456e1"},
+		M{"a": float64(1234560)},
 	}, {
 		"a: 123456E1\n",
-		M{"a": "123456E1"},
+		M{"a": float64(1234560)},
 	},
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{

--- a/encode_test.go
+++ b/encode_test.go
@@ -88,6 +88,9 @@ var marshalTests = []struct {
 		map[string]interface{}{"v": "10"},
 		"v: \"10\"\n",
 	}, {
+		map[string]interface{}{"v": "123e1"},
+		"v: \"123e1\"\n",
+	}, {
 		map[string]interface{}{"v": 0.1},
 		"v: 0.1\n",
 	}, {

--- a/resolve.go
+++ b/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {


### PR DESCRIPTION
The [+-] is optional after the exponent delineator.