### PR TITLE
Improved consistency of map key sorting.

### DIFF
--- a/sorter.go
+++ b/sorter.go
@@ -36,8 +36,41 @@ func (l keyList) Less(i, j int) bool {
 	if ak != reflect.String || bk != reflect.String {
 		return ak < bk
 	}
+
 	ar, br := []rune(a.String()), []rune(b.String())
 	for i := 0; i < len(ar) && i < len(br); i++ {
+		if unicode.IsDigit(ar[i]) && unicode.IsDigit(br[i]) {
+			// Count the number of leading zeros and digit sum for ar.
+			var asum int64
+			var ai, azeros int
+			for ai = i; ai < len(ar) && unicode.IsDigit(ar[ai]); ai++ {
+				asum = asum*10 + int64(ar[ai]-'0')
+				if asum == 0 && ar[ai] == '0' {
+					azeros++
+				}
+			}
+
+			// Count the number of leading zeros and digit sum for br.
+			var bsum int64
+			var bi, bzeroes int
+			for bi = i; bi < len(br) && unicode.IsDigit(br[bi]); bi++ {
+				bsum = bsum*10 + int64(br[bi]-'0')
+				if bsum == 0 && br[bi] == '0' {
+					bzeroes++
+				}
+			}
+
+			switch {
+			case asum != bsum:
+				return asum < bsum
+			case azeros != bzeroes:
+				return azeros < bzeroes
+			default:
+				i = ai
+				continue
+			}
+		}
+
 		if ar[i] == br[i] {
 			continue
 		}
@@ -48,29 +81,6 @@ func (l keyList) Less(i, j int) bool {
 		}
 		if al || bl {
 			return bl
-		}
-		var ai, bi int
-		var an, bn int64
-		if ar[i] == '0' || br[i] == '0' {
-			for j := i-1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
-				if ar[j] != '0' {
-					an = 1
-					bn = 1
-					break
-				}
-			}
-		}
-		for ai = i; ai < len(ar) && unicode.IsDigit(ar[ai]); ai++ {
-			an = an*10 + int64(ar[ai]-'0')
-		}
-		for bi = i; bi < len(br) && unicode.IsDigit(br[bi]); bi++ {
-			bn = bn*10 + int64(br[bi]-'0')
-		}
-		if an != bn {
-			return an < bn
-		}
-		if ai != bi {
-			return ai < bi
 		}
 		return ar[i] < br[i]
 	}

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -1,0 +1,83 @@
+package yaml
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestLessFullyTransitive checks that the Less function is fully transitive.
+// This means that for every element in a known list, checking that the element
+// is greater then all elements before it, and less than all elements after it.
+func TestLessFullyTransitive(t *testing.T) {
+	order := []interface{}{
+		false,
+		true,
+		1,
+		uint(1),
+		1.0,
+		1.1,
+		1.2,
+		2,
+		uint(2),
+		2.0,
+		2.1,
+		"",
+		".1",
+		".2",
+		".a",
+		"1",
+		"2",
+		"a!10",
+		"a/0001",
+		"a/002",
+		"a/3",
+		"a/10",
+		"a/11",
+		"a/0012",
+		"a/100",
+		"a~10",
+		"ab/1",
+		"b/1",
+		"b/01",
+		"b/2",
+		"b/02",
+		"b/3",
+		"b/03",
+		"b1",
+		"b01",
+		"b3",
+		"c2.10",
+		"c10.2",
+		"d1",
+		"d7",
+		"d7abc",
+		"d12",
+		"d12a",
+		"z1a",
+		"z01",
+		"z13",
+	}
+
+	var kl = make(keyList, len(order))
+	for index, item := range order {
+		kl[index] = reflect.ValueOf(item)
+	}
+
+	// Compare every element, against every other element.
+	for indexFirst, itemFirst := range kl {
+		for indexSecond, itemSecond := range kl {
+			switch {
+			case indexFirst == indexSecond:
+				continue
+			case indexFirst < indexSecond:
+				if !kl.Less(indexFirst, indexSecond) {
+					t.Fatalf("expected %v < %v", itemFirst, itemSecond)
+				}
+			case indexFirst > indexSecond:
+				if kl.Less(indexFirst, indexSecond) {
+					t.Fatalf("expected %v > %v", itemFirst, itemSecond)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
There are some specific sets of keys that will be sorted inconsistently when marshaling. This can result in YAML documents that change significantly when re-marshaled, even if the underlying data remains identical.

I noticed this when marshaling a cache object (vanilla `map[string]string`) as part of a CI pipeline. The resulting (`git`) diff kept thrashing even if the cache data didn't.

As a minimal repro, I was able to find a set of keys that trigger this behavior. These keys do not have a strict ordering, as `z01 < z12`, `z12 < z1a`, **and** `z1a < z01`, creating a cycle. 

```go
func (s *S) TestSortedMap(c *C) {
	var (
		m = map[string]struct{}{
			"z01": {},
			"z12": {},
			"z1a": {},
		}

		expected = []byte("z01: {}\nz12: {}\nz1a: {}\n")
	)

	// Repeatedly marshal the same exact data, and check for any differences in
	// the output.
	for i := 0; i < 100; i++ {
		actual, err := yaml.Marshal(m)
		c.Assert(err, IsNil)

		if bytes.Compare(expected, actual) != 0 {
			fmt.Printf("Expected: \n%s\n", string(expected))
			fmt.Printf("Actual:   \n%s\n", string(actual))
			c.Fatalf("Difference on iteration %d", i)
		}
	}
}
```

```
Expected: 
z01: {}
z12: {}
z1a: {}

Actual:   
z12: {}
z1a: {}
z01: {}

<snip>
Error: Difference on iteration 4
```

The changes in this PR removes this inconsistency, while maintaining the same ordering behavior asserted in the existing test suite.

Some specific feedback that I think this PR needs:
- How you would like to test functionality of private (`yaml`) package contents? - All current tests exist in an external (`yaml_test`) package, and cannot assert this behavior _directly_.
- How would you like to test functionality that has not made it into `v2` (or `v3`, etc)? - All current tests `import "gopkg.in/yaml.v2"` which would make new tests fail as that package doesn't yet contain the corresponding new fixes.

Looking forward to hearing your feedback, cheers!