### PR TITLE
Fix -0b on 32-bit systems

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -130,9 +130,6 @@ var unmarshalTests = []struct {
 		"bin: -0b101010",
 		map[string]interface{}{"bin": -42},
 	}, {
-		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
-		map[string]interface{}{"bin": -9223372036854775808},
-	}, {
 		"decimal: +685_230",
 		map[string]int{"decimal": 685230},
 	},
@@ -301,6 +298,10 @@ var unmarshalTests = []struct {
 	{
 		"int64_min: -9223372036854775808",
 		map[string]int64{"int64_min": math.MinInt64},
+	},
+	{
+		"int64_min_base2: -0b1000000000000000000000000000000000000000000000000000000000000000",
+		map[string]int64{"int64_min_base2": math.MinInt64},
 	},
 	{
 		"int64_neg_base2: -0b111111111111111111111111111111111111111111111111111111111111111",

--- a/resolve.go
+++ b/resolve.go
@@ -182,7 +182,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 			} else if strings.HasPrefix(plain, "-0b") {
 				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
 				if err == nil {
-					if true || intv == int64(int(intv)) {
+					if intv == int64(int(intv)) {
 						return yaml_INT_TAG, int(intv)
 					} else {
 						return yaml_INT_TAG, intv


### PR DESCRIPTION
7b8fd2d introduced a regression on 32-bit systems where -0b values would be
cast to an Int before being returned as a Int64, meaning that on 32-bit
systems, any negative value smaller than MinInt32 would get wrapped around and
returned incorrectly, causing the int64_neg_base2 decode_test to fail.

The test case also causes the bin test to fail on 32-bit systems because it
presumes the 64-bit edge case value can fit within an Int, which is not the
case on a 32-bit system.

Move the newly-introduced test case to the Int64-specific test cases, and
remove the undesirable coersion of Int64 values to Int when they do not fit.

Fixes #441.