### PR TITLE
Fix decoding of quoted scalars "null" and "~"

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -291,7 +291,7 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "~" || n.value == "" && n.implicit) {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && ((n.value == "null" || n.value == "~" || n.value == "") && n.implicit) {
 		return out, false, false
 	}
 	again := true

--- a/decode_test.go
+++ b/decode_test.go
@@ -1059,6 +1059,31 @@ func (s *S) TestUnmarshalerRetry(c *C) {
 	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1}))
 }
 
+type wrapUnmarshaler struct {
+	value interface{}
+}
+
+func (wu *wrapUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return unmarshal(&wu.value)
+}
+
+func (s *S) TestUnmarshalerCalledOnQuotedNull(c *C) {
+	var data []*wrapUnmarshaler
+	err := yaml.Unmarshal([]byte(`
+- "null"
+- "~"
+- null
+- ~
+`), &data)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []*wrapUnmarshaler{
+		&wrapUnmarshaler{"null"},
+		&wrapUnmarshaler{"~"},
+		nil,
+		nil,
+	})
+}
+
 // From http://yaml.org/type/merge.html
 var mergeTests = `
 anchors:


### PR DESCRIPTION
Quoted scalars "null" and "~" should be handled the same way
as any other strings which includes calling UnmarshalYAML method.