### PR TITLE
Feature (v3): Add a function to set the desired line length of an Encoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ go:
     - "1.12"
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/yaml.v3

--- a/encode.go
+++ b/encode.go
@@ -522,3 +522,7 @@ func (e *encoder) node(node *Node) {
 		e.emitScalar(value, node.Anchor, tag, style, []byte(node.HeadComment), []byte(node.LineComment), []byte(node.FootComment))
 	}
 }
+
+func (e *encoder) setWidth(width int) {
+	yaml_emitter_set_width(&e.emitter, width)
+}

--- a/yaml.go
+++ b/yaml.go
@@ -260,6 +260,12 @@ func (e *Encoder) SetIndent(spaces int) {
 	e.encoder.indent = spaces
 }
 
+// SetLineLength changes the desired line wrapping length.
+// if characters is negative, '1<<31 - 1' is used.
+func (e *Encoder) SetLineLength(characters int) {
+	e.encoder.setWidth(characters)
+}
+
 // Close closes the encoder by writing any remaining data.
 // It does not write a stream terminating string "...".
 func (e *Encoder) Close() (err error) {


### PR DESCRIPTION
This PR exposes a function `func (e *Encoder) SetLineLength(characters int)` that allows setting the line wrap length of an encoder. The interface was intended to have a very similar style to the SetIndent function `func (e *Encoder) SetIndent(spaces int)`, implemented [here](https://github.com/go-yaml/yaml/commit/2c9fce8bede05098317e715fe41cc2db4847ea0b).

Internally, it uses the existing function `func yaml_emitter_set_width(emitter *yaml_emitter_t, width int)`, which was previously unused.

This relates to several issues (#387, #348, #166) and a previous PR (#329).