### PR TITLE
node: add more data about lines, columns, indexes

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -389,6 +389,11 @@ type Node struct {
 	// These fields are not respected when encoding the node.
 	Line   int
 	Column int
+	Index  int
+
+	LineEnd   int
+	ColumnEnd int
+	IndexEnd  int
 }
 
 // LongTag returns the long form of the tag that indicates the data type for


### PR DESCRIPTION
Add Index, LineEnd, ColumnEnd, and IndexEnd to Node. *End mark the end
of where that node occurs in the source. Index* marks the index into the
input stream.

Fixes https://github.com/go-yaml/yaml/issues/458

Edit: Needs test updates, will push another commit with those