### PR TITLE
Feature (v3): Add a permissive unmarshal function similar to v2's 'yaml.Unmarshal'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ go:
     - "1.12"
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/yaml.v3

--- a/decode.go
+++ b/decode.go
@@ -324,11 +324,11 @@ var (
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )
 
-func newDecoder() *decoder {
+func newDecoder(strict bool) *decoder {
 	d := &decoder{
 		stringMapType:  stringMapType,
 		generalMapType: generalMapType,
-		uniqueKeys:     true,
+		uniqueKeys:     strict,
 	}
 	d.aliases = make(map[*Node]bool)
 	return d

--- a/yaml.go
+++ b/yaml.go
@@ -86,6 +86,12 @@ type Marshaler interface {
 // supported tag options.
 //
 func Unmarshal(in []byte, out interface{}) (err error) {
+	return unmarshal(in, out, true)
+}
+
+// UnmarshalPermissive acts as Unmarshal but allows duplicate keys within
+// the input data.
+func UnmarshalPermissive(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
 
@@ -117,7 +123,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (dec *Decoder) Decode(v interface{}) (err error) {
-	d := newDecoder()
+	d := newDecoder(true)
 	d.knownFields = dec.knownFields
 	defer handleErr(&err)
 	node := dec.parser.parse()
@@ -140,7 +146,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (n *Node) Decode(v interface{}) (err error) {
-	d := newDecoder()
+	d := newDecoder(true)
 	defer handleErr(&err)
 	out := reflect.ValueOf(v)
 	if out.Kind() == reflect.Ptr && !out.IsNil() {
@@ -155,7 +161,7 @@ func (n *Node) Decode(v interface{}) (err error) {
 
 func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	defer handleErr(&err)
-	d := newDecoder()
+	d := newDecoder(strict)
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()


### PR DESCRIPTION
yaml.UnmarshalPermissive allows duplicate keys

This was added in response to a few comments (https://github.com/go-yaml/yaml/issues/363#issuecomment-439719079, https://github.com/go-yaml/yaml/issues/363#issuecomment-510709413) and the need to not break backwards compatibility for Kubernetes (https://github.com/kubernetes-sigs/yaml/pull/26#pullrequestreview-260991270).