### PR TITLE
travis should use the v3 import path not v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ go:
     - "1.12"
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/yaml.v3


### PR DESCRIPTION
otherwise tests of functions that do not exist in v2 fail

EDIT:
Also, without this pr tests are run against the current v3 code, not the code in the pr
This largely invalidates the point of CI