### PR TITLE
Bugfix (v3): Marshal yaml 1.1 bool strings as explicit strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ go:
     - "1.12"
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/yaml.v3

--- a/decode.go
+++ b/decode.go
@@ -627,12 +627,9 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		case string:
 			// This offers some compatibility with the 1.1 spec (https://yaml.org/type/bool.html).
 			// It only works if explicitly attempting to unmarshal into a typed bool value.
-			switch resolved {
-			case "y", "Y", "yes", "Yes", "YES", "on", "On", "ON":
-				out.SetBool(true)
-				return true
-			case "n", "N", "no", "No", "NO", "off", "Off", "OFF":
-				out.SetBool(false)
+			val, found := boolMap[resolved]
+			if found {
+				out.SetBool(val)
 				return true
 			}
 		}

--- a/encode.go
+++ b/encode.go
@@ -320,6 +320,11 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 		// there's no need to quote it.
 		rtag, _ := resolve("", s)
 		canUsePlain = rtag == strTag && !isBase60Float(s)
+
+		// Check to see if this is a v1.1 yaml bool string
+		// if it is, require quotes to preserve backwards compatibility
+		_, is11BoolString := boolMap[s]
+		canUsePlain = !is11BoolString && canUsePlain
 	}
 	// Note: it's possible for user code to emit invalid YAML
 	// if they explicitly specify a tag and a string containing

--- a/encode_test.go
+++ b/encode_test.go
@@ -422,6 +422,11 @@ var marshalTests = []struct {
 		map[string]string{"a": "\tB\n\tC\n"},
 		"a: |\n    \tB\n    \tC\n",
 	},
+	// the strings "yes" and "no" should be marshalled with quotes
+	{
+		map[string]string{"a": "yes", "b": "no"},
+		"a: \"yes\"\nb: \"no\"\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -422,10 +422,38 @@ var marshalTests = []struct {
 		map[string]string{"a": "\tB\n\tC\n"},
 		"a: |\n    \tB\n    \tC\n",
 	},
-	// the strings "yes" and "no" should be marshalled with quotes
+	// yaml 1.1 bool strings should be marshalled with quotes to preserve compatibility
+	{
+		map[string]string{"a": "y", "b": "n"},
+		"a: \"y\"\nb: \"n\"\n",
+	},
+	{
+		map[string]string{"a": "Y", "b": "N"},
+		"a: \"Y\"\nb: \"N\"\n",
+	},
 	{
 		map[string]string{"a": "yes", "b": "no"},
 		"a: \"yes\"\nb: \"no\"\n",
+	},
+	{
+		map[string]string{"a": "Yes", "b": "No"},
+		"a: \"Yes\"\nb: \"No\"\n",
+	},
+	{
+		map[string]string{"a": "YES", "b": "NO"},
+		"a: \"YES\"\nb: \"NO\"\n",
+	},
+	{
+		map[string]string{"a": "on", "b": "off"},
+		"a: \"on\"\nb: \"off\"\n",
+	},
+	{
+		map[string]string{"a": "On", "b": "Off"},
+		"a: \"On\"\nb: \"Off\"\n",
+	},
+	{
+		map[string]string{"a": "ON", "b": "OFF"},
+		"a: \"ON\"\nb: \"OFF\"\n",
 	},
 }
 

--- a/resolve.go
+++ b/resolve.go
@@ -31,6 +31,7 @@ type resolveMapItem struct {
 
 var resolveTable = make([]byte, 256)
 var resolveMap = make(map[string]resolveMapItem)
+var boolMap = make(map[string]bool)
 
 func init() {
 	t := resolveTable
@@ -64,6 +65,26 @@ func init() {
 		for _, s := range item.l {
 			m[s] = resolveMapItem{item.v, item.tag}
 		}
+	}
+
+	// the remaining bool values from the 1.1 spec (https://yaml.org/type/bool.html)
+	boolMap = map[string]bool{
+		"y": true,
+		"Y": true,
+		"yes": true,
+		"Yes": true,
+		"YES": true,
+		"on": true,
+		"On": true,
+		"ON": true,
+		"n": false,
+		"N": false,
+		"no": false,
+		"No": false,
+		"NO": false,
+		"off": false,
+		"Off": false,
+		"OFF": false,
 	}
 }
 


### PR DESCRIPTION
String values matching a boolean literal from the [yaml 1.1 spec](https://yaml.org/type/bool.html) should be rendered with quotes to ensure backwards compatibility. This fixes #489. 