### PR TITLE
use double quotes for string containing only equal sign

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -320,6 +320,10 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 		rtag, _ := resolve("", s)
 		canUsePlain = rtag == yaml_STR_TAG && !isBase60Float(s)
 	}
+
+	if s == "=" {
+		canUsePlain = false
+	}
 	// Note: it's possible for user code to emit invalid YAML
 	// if they explicitly specify a tag and a string containing
 	// text that's incompatible with that tag.


### PR DESCRIPTION
triggers yaml_DOUBLE_QUOTED_SCALAR_STYLE if string contains only equal character