### PR TITLE
Remove superfluous nil checks in decode.go

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -422,14 +422,10 @@ func (d *decoder) scalar(n *node, out reflect.Value) bool {
 			out.SetString(resolved.(string))
 			return true
 		}
-		if resolved != nil {
-			out.SetString(n.value)
-			return true
-		}
+		out.SetString(n.value)
+		return true
 	case reflect.Interface:
-		if resolved == nil {
-			out.Set(reflect.Zero(out.Type()))
-		} else if tag == yaml_TIMESTAMP_TAG {
+		if tag == yaml_TIMESTAMP_TAG {
 			// It looks like a timestamp but for backward compatibility
 			// reasons we set it as a string, so that code that unmarshals
 			// timestamp-like values into interface{} will continue to


### PR DESCRIPTION
When we reach those lines we resolved can never be nil since it is already checked on line 385.
Found with nilness analyzer (see https://godoc.org/golang.org/x/tools/go/analysis/passes/nilness)