### PR TITLE
Typo: "Decoder" not "Decorder"

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
-// A Decorder reads and decodes YAML values from an input stream.
+// A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	strict bool
 	parser *parser


### PR DESCRIPTION
Minor typo. Thanks for the great work—I used it yesterday.