### PR TITLE
FIX: isStringMap should just check the keys of map

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -795,7 +795,7 @@ func isStringMap(n *Node) bool {
 		return false
 	}
 	l := len(n.Content)
-	for i := 0; i < l; i++ {
+	for i := 0; i < l; i += 2 {
 		if n.Content[i].ShortTag() != strTag {
 			return false
 		}


### PR DESCRIPTION
i'm not sure the fix is on the right way, but it works in my situation.
i think your old code check the key and also the value, which may failed to use `string map` when some value are not `!!str`, even all keys of map are `!!str`.