### PR TITLE
Support for top-level field parameters that apply to all children.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -708,7 +709,14 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 		if !d.unmarshal(ni, name) {
 			continue
 		}
-		if info, ok := sinfo.FieldsMap[name.String()]; ok {
+		nameStr := name.String()
+		nameStrLowerCase := strings.ToLower(nameStr)
+		if info, ok := sinfo.FieldsMap[nameStrLowerCase]; ok {
+			if info.CaseInsensitive {
+				nameStr = nameStrLowerCase
+			}
+		}
+		if info, ok := sinfo.FieldsMap[nameStr]; ok {
 			if d.strict {
 				if doneFields[info.Id] {
 					d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s already set in type %s", ni.line+1, name.String(), out.Type()))

--- a/decode.go
+++ b/decode.go
@@ -225,11 +225,12 @@ func (p *parser) mapping() *node {
 // Decoder, unmarshals a node into a provided value.
 
 type decoder struct {
-	doc     *node
-	aliases map[*node]bool
-	mapType reflect.Type
-	terrors []string
-	strict  bool
+	doc          *node
+	aliases      map[*node]bool
+	mapType      reflect.Type
+	terrors      []string
+	strict       bool
+	globalParams params
 }
 
 var (
@@ -241,8 +242,8 @@ var (
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )
 
-func newDecoder(strict bool) *decoder {
-	d := &decoder{mapType: defaultMapType, strict: strict}
+func newDecoder(strict bool, globalParams params) *decoder {
+	d := &decoder{mapType: defaultMapType, strict: strict, globalParams: globalParams}
 	d.aliases = make(map[*node]bool)
 	return d
 }
@@ -681,7 +682,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 }
 
 func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
-	sinfo, err := getStructInfo(out.Type())
+	sinfo, err := getStructInfo(out.Type(), d.globalParams)
 	if err != nil {
 		panic(err)
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -510,6 +510,29 @@ var unmarshalTests = []struct {
 		}{1, map[string]int{"b": 2, "c": 3}},
 	},
 
+	// Case insensitivity
+	{
+		"Name: jpap\nb: 2\n",
+		&struct {
+			Name string `yaml:",insensitive"`
+			B    int
+		}{"jpap", 2},
+	},
+	{
+		"NAME: jpap\nb: 2\n",
+		&struct {
+			Name string `yaml:",insensitive"`
+			B    int
+		}{"jpap", 2},
+	},
+	{
+		"name: jpap\nb: 2\n",
+		&struct {
+			Name string `yaml:",insensitive"`
+			B    int
+		}{"jpap", 2},
+	},
+
 	// bug 1243827
 	{
 		"a: -b_c",

--- a/encode.go
+++ b/encode.go
@@ -33,19 +33,20 @@ type encoder struct {
 	flow    bool
 	// doneInit holds whether the initial stream_start_event has been
 	// emitted.
-	doneInit bool
+	doneInit     bool
+	globalParams params
 }
 
-func newEncoder() *encoder {
-	e := &encoder{}
+func newEncoder(globalParams params) *encoder {
+	e := &encoder{globalParams: globalParams}
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
 	return e
 }
 
-func newEncoderWithWriter(w io.Writer) *encoder {
-	e := &encoder{}
+func newEncoderWithWriterAndParams(w io.Writer, globalParams params) *encoder {
+	e := &encoder{globalParams: globalParams}
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_writer(&e.emitter, w)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -206,7 +207,7 @@ func (e *encoder) itemsv(tag string, in reflect.Value) {
 }
 
 func (e *encoder) structv(tag string, in reflect.Value) {
-	sinfo, err := getStructInfo(in.Type())
+	sinfo, err := getStructInfo(in.Type(), e.globalParams)
 	if err != nil {
 		panic(err)
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -410,6 +410,54 @@ func (s *S) TestMarshal(c *C) {
 	}
 }
 
+var marshalWithParamsTests = []struct {
+	value  interface{}
+	data   string
+	params string
+}{
+
+	// Conditional flag
+	{
+		&struct {
+			A int "a"
+			B int "b"
+		}{1, 0},
+		"a: 1\n",
+		"omitempty",
+	},
+
+	// Struct inlining
+	{
+		&struct {
+			A int
+			C inlineB
+		}{1, inlineB{2, inlineC{3}}},
+		"a: 1\nb: 2\nc: 3\n",
+		"inline",
+	},
+
+	// Map inlining
+	{
+		&struct {
+			A int
+			C map[string]int
+		}{1, map[string]int{"b": 2, "c": 3}},
+		"a: 1\nb: 2\nc: 3\n",
+		"inline",
+	},
+}
+
+func (s *S) TestMarshalWithParams(c *C) {
+	defer os.Setenv("TZ", os.Getenv("TZ"))
+	os.Setenv("TZ", "UTC")
+	for i, item := range marshalWithParamsTests {
+		c.Logf("test %d: %q", i, item.data)
+		data, err := yaml.MarshalWithParams(item.value, item.params)
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, item.data)
+	}
+}
+
 func (s *S) TestEncoderSingleDocument(c *C) {
 	for i, item := range marshalTests {
 		c.Logf("test %d. %q", i, item.data)


### PR DESCRIPTION
Fixes go-yaml#512.

(This PR builds on another PR of mine, #513.)