### PR TITLE
Add large document benchmarks, tune alias heuristic, add max depth limits

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,123 @@
+package yaml_test
+
+import (
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type testcase struct {
+	name  string
+	data  []byte
+	error string
+}
+
+func testcases() []testcase {
+	return []testcase{
+		{
+			name:  "1000kb of maps with 100 aliases",
+			data:  []byte(`{a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-100) + `], b: &b [*a` + strings.Repeat(`,*a`, 99) + `]}`),
+			error: "yaml: document contains excessive aliasing",
+		},
+		{
+			name:  "1000kb of deeply nested slices",
+			data:  []byte(strings.Repeat(`[`, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name:  "1000kb of deeply nested maps",
+			data:  []byte("x: " + strings.Repeat(`{`, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name:  "1000kb of deeply nested indents",
+			data:  []byte(strings.Repeat(`- `, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name: "1000kb of 1000-indent lines",
+			data: []byte(strings.Repeat(strings.Repeat(`- `, 1000)+"\n", 1024/2)),
+		},
+		{name: "1kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1*1024/4-1) + `]`)},
+		{name: "10kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 10*1024/4-1) + `]`)},
+		{name: "100kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 100*1024/4-1) + `]`)},
+		{name: "1000kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-1) + `]`)},
+	}
+}
+
+func (s *S) TestLimits(c *C) {
+	if testing.Short() {
+		return
+	}
+	for _, tc := range testcases() {
+		var v interface{}
+		err := yaml.Unmarshal(tc.data, &v)
+		if len(tc.error) > 0 {
+			c.Assert(err, ErrorMatches, tc.error, Commentf("testcase: %s", tc.name))
+		} else {
+			c.Assert(err, IsNil, Commentf("testcase: %s", tc.name))
+		}
+	}
+}
+
+func Benchmark1000KB100Aliases(b *testing.B) {
+	benchmark(b, "1000kb of maps with 100 aliases")
+}
+func Benchmark1000KBDeeplyNestedSlices(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested slices")
+}
+func Benchmark1000KBDeeplyNestedMaps(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested maps")
+}
+func Benchmark1000KBDeeplyNestedIndents(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested indents")
+}
+func Benchmark1000KB1000IndentLines(b *testing.B) {
+	benchmark(b, "1000kb of 1000-indent lines")
+}
+func Benchmark1KBMaps(b *testing.B) {
+	benchmark(b, "1kb of maps")
+}
+func Benchmark10KBMaps(b *testing.B) {
+	benchmark(b, "10kb of maps")
+}
+func Benchmark100KBMaps(b *testing.B) {
+	benchmark(b, "100kb of maps")
+}
+func Benchmark1000KBMaps(b *testing.B) {
+	benchmark(b, "1000kb of maps")
+}
+
+func benchmark(b *testing.B, name string) {
+	var tc testcase
+	for _, t := range testcases() {
+		if t.name == name {
+			tc = t
+			break
+		}
+	}
+	if tc.name != name {
+		b.Errorf("testcase %q not found", name)
+		return
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var v interface{}
+		err := yaml.Unmarshal(tc.data, &v)
+		if len(tc.error) > 0 {
+			if err == nil {
+				b.Errorf("expected error, got none")
+			} else if err.Error() != tc.error {
+				b.Errorf("expected error '%s', got '%s'", tc.error, err.Error())
+			}
+		} else {
+			if err != nil {
+				b.Errorf("unexpected error: %v", err)
+			}
+		}
+	}
+}

--- a/decode.go
+++ b/decode.go
@@ -318,12 +318,37 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 	return out, false, false
 }
 
+const (
+	// 400,000 decode operations is ~500kb of dense object declarations, or ~5kb of dense object declarations with 10000% alias expansion
+	alias_ratio_range_low = 400000
+	// 4,000,000 decode operations is ~5MB of dense object declarations, or ~4.5MB of dense object declarations with 10% alias expansion
+	alias_ratio_range_high = 4000000
+	// alias_ratio_range is the range over which we scale allowed alias ratios
+	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
+)
+
+func allowedAliasRatio(decodeCount int) float64 {
+	switch {
+	case decodeCount <= alias_ratio_range_low:
+		// allow 99% to come from alias expansion for small-to-medium documents
+		return 0.99
+	case decodeCount >= alias_ratio_range_high:
+		// allow 10% to come from alias expansion for very large documents
+		return 0.10
+	default:
+		// scale smoothly from 99% down to 10% over the range.
+		// this maps to 396,000 - 400,000 allowed alias-driven decodes over the range.
+		// 400,000 decode operations is ~100MB of allocations in worst-case scenarios (single-item maps).
+		return 0.99 - 0.89*(float64(decodeCount-alias_ratio_range_low)/alias_ratio_range)
+	}
+}
+
 func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 	d.decodeCount++
 	if d.aliasDepth > 0 {
 		d.aliasCount++
 	}
-	if d.aliasCount > 100 && d.decodeCount > 1000 && float64(d.aliasCount)/float64(d.decodeCount) > 0.99 {
+	if d.aliasCount > 100 && d.decodeCount > 1000 && float64(d.aliasCount)/float64(d.decodeCount) > allowedAliasRatio(d.decodeCount) {
 		failf("document contains excessive aliasing")
 	}
 	switch n.kind {

--- a/scannerc.go
+++ b/scannerc.go
@@ -906,6 +906,9 @@ func yaml_parser_remove_simple_key(parser *yaml_parser_t) bool {
 	return true
 }
 
+// max_flow_level limits the flow_level
+const max_flow_level = 10000
+
 // Increase the flow level and resize the simple key list if needed.
 func yaml_parser_increase_flow_level(parser *yaml_parser_t) bool {
 	// Reset the simple key on the next level.
@@ -913,6 +916,11 @@ func yaml_parser_increase_flow_level(parser *yaml_parser_t) bool {
 
 	// Increase the flow level.
 	parser.flow_level++
+	if parser.flow_level > max_flow_level {
+		return yaml_parser_set_scanner_error(parser,
+			"while increasing flow level", parser.simple_keys[len(parser.simple_keys)-1].mark,
+			fmt.Sprintf("exceeded max depth of %d", max_flow_level))
+	}
 	return true
 }
 
@@ -924,6 +932,9 @@ func yaml_parser_decrease_flow_level(parser *yaml_parser_t) bool {
 	}
 	return true
 }
+
+// max_indents limits the indents stack size
+const max_indents = 10000
 
 // Push the current indentation level to the stack and set the new level
 // the current column is greater than the indentation level.  In this case,
@@ -939,6 +950,11 @@ func yaml_parser_roll_indent(parser *yaml_parser_t, column, number int, typ yaml
 		// indentation level.
 		parser.indents = append(parser.indents, parser.indent)
 		parser.indent = column
+		if len(parser.indents) > max_indents {
+			return yaml_parser_set_scanner_error(parser,
+				"while increasing indent level", parser.simple_keys[len(parser.simple_keys)-1].mark,
+				fmt.Sprintf("exceeded max depth of %d", max_indents))
+		}
 
 		// Create a token and insert it into the queue.
 		token := yaml_token_t{


### PR DESCRIPTION
This PR addresses the following items:

#### Parse time of excessively deep nested or indented documents
Parsing these documents is non-linear; limiting stack depth to 10,000 keeps parse times of pathological documents sub-second (~.25 seconds in benchmarks)

#### Alias node expansion limits
The current limit allows 10,000% expansion, which is too permissive for large documents.

Limiting to 10% expansion for larger documents allows callers to use input size as an effective way to limit resource usage. Continuing to allow larger expansion rates (up to the current 10,000% limit) for smaller documents does not unduly affect memory use.

This PR bounds decode operations from alias expansion to ~400,000 operations for small documents (worst-case ~100-150MB) or 10% of the input document for large documents, whichever is greater.

Using the same benchmark methodology as is included in this PR, memory growth of documents at a given size was measured with no alias use, and with alias use up to the point where the document was rejected:
```
Benchmark10KBMaps-8                    	     300	   5170631 ns/op	 2178170 B/op	   30780 allocs/op
Benchmark10KB100Aliases-8              	      10	 157137076 ns/op	63367120 B/op	 1015200 allocs/op
58MB / 2800% memory growth

Benchmark100KBMaps-8                   	      30	  49184677 ns/op	22002812 B/op	  307269 allocs/op
Benchmark100KB100Aliases-8             	       5	 324828977 ns/op	121346915 B/op	 1911494 allocs/op
94MB / 450% memory growth

Benchmark500KBMaps-8         	       5	 242092357 ns/op	110320752 B/op	 1536076 allocs/op
Benchmark500KB100Aliases-8   	       2	 646305778 ns/op	262996448 B/op	 3996330 allocs/op
145MB / 140% memory growth

Benchmark1000KBMaps-8                  	       2	 515058247 ns/op	220560496 B/op	 3072079 allocs/op
Benchmark1000KB100Aliases-8            	       1	1007482569 ns/op	393118304 B/op	 5832425 allocs/op
164MB / 78% memory growth

Benchmark2000KBMaps-8         	       2	 988554128 ns/op	440802576 B/op	 6144084 allocs/op
Benchmark2000KB100Aliases-8   	       1	1500724350 ns/op	607745104 B/op	 8809907 allocs/op
159MB / 38% memory growth

Benchmark3000KBMaps-8         	       1	1558944296 ns/op	662789424 B/op	 9216086 allocs/op
Benchmark3000KB100Aliases-8   	       1	2130929511 ns/op	804852592 B/op	11394373 allocs/op
135MB / 20% memory growth

Benchmark10000KBMaps-8                 	       1	4861632275 ns/op	2199723248 B/op	30720091 allocs/op
Benchmark10000KB100Aliases-8           	       1	6217891286 ns/op	2359273744 B/op	32710176 allocs/op
150MB / 7% memory growth
```

#### Benchmarks
* Benchmarks for decoding large documents with lots of allocations
* Benchmarks for runtime of decoding very deep documents

```
$ go test . -bench . -benchmem -run None
goos: darwin
goarch: amd64
pkg: gopkg.in/yaml.v2
Benchmark1000KB100Aliases-8            	       1	1101005272 ns/op	393203632 B/op	 5833714 allocs/op
Benchmark1000KBDeeplyNestedSlices-8    	       5	 212081876 ns/op	 4690417 B/op	    9070 allocs/op
Benchmark1000KBDeeplyNestedMaps-8      	       5	 207762964 ns/op	 4690702 B/op	    9074 allocs/op
Benchmark1000KBDeeplyNestedIndents-8   	     300	   4000775 ns/op	 2970468 B/op	   10085 allocs/op
Benchmark1000KB1000IndentLines-8       	       3	 400336822 ns/op	143718512 B/op	 4093516 allocs/op
Benchmark1KBMaps-8                     	    3000	    451697 ns/op	  218984 B/op	    3126 allocs/op
Benchmark10KBMaps-8                    	     300	   4930581 ns/op	 2178172 B/op	   30780 allocs/op
Benchmark100KBMaps-8                   	      30	  48219421 ns/op	22002820 B/op	  307269 allocs/op
Benchmark1000KBMaps-8                  	       3	 477795963 ns/op	220560496 B/op	 3072079 allocs/op
PASS
ok  	gopkg.in/yaml.v2	15.168s
```