### PR TITLE
add Encoder.SetLineLength API and change imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ go:
     - 1.9
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/jmhodges/yaml.v2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Introduction
 ------------
 
+This is a fork of gopkg.in/yaml.v2 that adds the `SetLineLength` method to
+`Encoder`. The patch was taken from https://github.com/go-yaml/yaml/pull/455
+
 The yaml package enables Go programs to comfortably encode and decode YAML
 values. It was developed within [Canonical](https://www.canonical.com) as
 part of the [juju](https://juju.ubuntu.com) project, and is based on a
@@ -20,18 +23,18 @@ supported since they're a poor design and are gone in YAML 1.2.
 Installation and usage
 ----------------------
 
-The import path for the package is *gopkg.in/yaml.v2*.
+The import path for the package is *gopkg.in/jmhodges/yaml.v2*.
 
 To install it, run:
 
-    go get gopkg.in/yaml.v2
+    go get gopkg.in/jmhodges/yaml.v2
 
 API documentation
 -----------------
 
 If opened in a browser, the import path itself leads to the API documentation:
 
-  * [https://gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)
+  * [https://gopkg.in/jmhodges/yaml.v2](https://gopkg.in/jmhodges/yaml.v2)
 
 API stability
 -------------
@@ -55,7 +58,7 @@ import (
         "fmt"
         "log"
 
-        "gopkg.in/yaml.v2"
+        "gopkg.in/jmhodges/yaml.v2"
 )
 
 var data = `

--- a/decode_test.go
+++ b/decode_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/jmhodges/yaml.v2"
 )
 
 var unmarshalIntTest = 123
@@ -856,14 +856,14 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
-		"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
-		"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
-		"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
-		"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
-		"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
-		"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
-		"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
-		"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
+			"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
+			"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
+			"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
+			"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
+			"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
+			"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
+			"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
+			"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
 		"yaml: document contains excessive aliasing",
 	},
 }

--- a/encode.go
+++ b/encode.go
@@ -388,3 +388,7 @@ func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_
 	e.must(yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(tag), []byte(value), implicit, implicit, style))
 	e.emit()
 }
+
+func (e *encoder) setWidth(width int) {
+	yaml_emitter_set_width(&e.emitter, width)
+}

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/jmhodges/yaml.v2"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v2"
+module gopkg.in/jmhodges/yaml.v2
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/limit_test.go
+++ b/limit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/jmhodges/yaml.v2"
 )
 
 var limitTests = []struct {

--- a/yaml.go
+++ b/yaml.go
@@ -233,6 +233,12 @@ func (e *Encoder) Encode(v interface{}) (err error) {
 	return nil
 }
 
+// SetLineLength changes the desired line wrapping length.
+// if characters is negative, '1<<31 - 1' is used.
+func (e *Encoder) SetLineLength(characters int) {
+	e.encoder.setWidth(characters)
+}
+
 // Close closes the encoder by writing any remaining data.
 // It does not write a stream terminating string "...".
 func (e *Encoder) Close() (err error) {


### PR DESCRIPTION
This adds the SetLineLength method to Encoder and changes the imports to the
jmhodges/yaml.v2 config.

The SetLineLength patch is adapated from
https://github.com/go-yaml/yaml/pull/455

The README got an update for folks needing this.