### PR TITLE
test gopkg.in/yaml.v3, not v2, in limit_test.go

### DIFF
--- a/limit_test.go
+++ b/limit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var limitTests = []struct {


### PR DESCRIPTION
otherwise the test is pretty useless
(I noticed because `go mod tidy` was adding v2 as a dependency, which seemed very wrong)