### PR TITLE
Proposal: Support repeated JSON documents

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -886,6 +886,14 @@ var decoderTests = []struct {
 		"hello",
 		"goodbye",
 	},
+}, {
+	// Parse repeated flow maps as separate documents, for compatibility with Go's
+	// encoding/json
+	"{ \"a\": \"b\" }\n{ \"c\": \"d\" }",
+	[]interface{}{
+		map[string]interface{}{"a": "b"},
+		map[string]interface{}{"c": "d"},
+	},
 }}
 
 func (s *S) TestDecoder(c *C) {

--- a/parserc.go
+++ b/parserc.go
@@ -321,7 +321,7 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_DOCUMENT_START_TOKEN {
+		if token.typ != yaml_DOCUMENT_START_TOKEN && token.typ != yaml_FLOW_MAPPING_START_TOKEN {
 			yaml_parser_set_parser_error(parser,
 				"did not find expected <document start>", token.start_mark)
 			return false
@@ -338,7 +338,9 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 			tag_directives:    tag_directives,
 			implicit:          false,
 		}
-		skip_token(parser)
+		if token.typ == yaml_DOCUMENT_START_TOKEN {
+			skip_token(parser)
+		}
 
 	} else {
 		// Parse the stream end.


### PR DESCRIPTION
Hello! I hope this PR-out-of-the-blue is welcome; please let me know if there's more I can do to introduce myself or improve the change.

This makes a modification to the `go-yaml` parser that allows it to parse repeated flow maps similarly to `encoding/json`.

The YAML syntax this change supports is not valid per the YAML 1.2 spec (at least as verified by https://hackage.haskell.org/package/YamlReference), but extends the grammer only slightly beyond the official spec, if I understand the parser correctly, and only to support syntax already parsed elsewhere in the Go ecosystem.

The main advantage of merging this change is that it would allow users of `go-yaml` to completely replace their use of `encoding/json` with `go-yaml` (as Pachyderm aims to do).

Thanks for considering this change, and please let me know if there's any other help or information I can provide!