### PR TITLE
Optimize a couple of nested loops in the scanner.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -722,6 +722,18 @@ var unmarshalTests = []struct {
 		"a: 5.5\n",
 		&struct{ A jsonNumberT }{"5.5"},
 	},
+	{
+		`
+a:
+  b
+b:
+  ? a
+  : a`,
+		&M{"a": "b",
+			"b": M{
+				"a": "a",
+			}},
+	},
 }
 
 type M map[interface{}]interface{}

--- a/limit_test.go
+++ b/limit_test.go
@@ -37,6 +37,8 @@ var limitTests = []struct {
 	{name: "10kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 10*1024/4-1) + `]`)},
 	{name: "100kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 100*1024/4-1) + `]`)},
 	{name: "1000kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-1) + `]`)},
+	{name: "1000kb of giant slice nested at max-depth", data: []byte(strings.Repeat(`[`, 10000) + `1` + strings.Repeat(`,1`, 1000*1024/2-20000-1) + strings.Repeat(`]`, 10000))},
+	{name: "1000kb of tokens nested at max-depth of non-simple-token maps", data: []byte("{a,a:\n" + strings.Repeat(" {a,a:", 10000-1) + `1` + strings.Repeat(",1", 1000*1024/2-6*10000-1) + strings.Repeat(`}`, 10000))},
 }
 
 func (s *S) TestLimits(c *C) {
@@ -80,6 +82,14 @@ func Benchmark100KBMaps(b *testing.B) {
 }
 func Benchmark1000KBMaps(b *testing.B) {
 	benchmark(b, "1000kb of maps")
+}
+
+func BenchmarkDeepSlice(b *testing.B) {
+	benchmark(b, "1000kb of giant slice nested at max-depth")
+}
+
+func BenchmarkDeepFlow(b *testing.B) {
+	benchmark(b, "1000kb of tokens nested at max-depth of non-simple-token maps")
 }
 
 func benchmark(b *testing.B, name string) {

--- a/yamlh.go
+++ b/yamlh.go
@@ -577,8 +577,9 @@ type yaml_parser_t struct {
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed bool                // May a simple key occur at the current position?
-	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simple_key_allowed             bool                // May a simple key occur at the current position?
+	simple_keys                    []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_min_possible_index int                 // Where in the stack should we restart scanning for staleness?
 
 	// Parser stuff
 

--- a/yamlh.go
+++ b/yamlh.go
@@ -577,9 +577,10 @@ type yaml_parser_t struct {
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed             bool                // May a simple key occur at the current position?
-	simple_keys                    []yaml_simple_key_t // The stack of simple keys.
-	simple_keys_min_possible_index int                 // Where in the stack should we restart scanning for staleness?
+	simple_key_allowed                   bool                // May a simple key occur at the current position?
+	simple_keys                          []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_min_possible_index       int                 // Where in the stack should we restart scanning for staleness?
+	simple_keys_possible_by_token_number map[int]struct{}    // Does this token_number represent a possible simple_key?
 
 	// Parser stuff
 


### PR DESCRIPTION
There are two places in scannerc.go where we iterate through the full simple_keys stack that I think we can avoid:
- when determining [whether a key is possible](https://github.com/go-yaml/yaml/blob/v2/scannerc.go#L641-L647)
- in the [staleness check](https://github.com/go-yaml/yaml/blob/v2/scannerc.go#L844-L861).

I've included a couple of test cases that show the bad behavior, even with the recent depth limits :

```
$ git checkout c9e8ea1b90fe07c9447c7cbcc212e927d6988388 && go test -run=NONE -bench=. -benchmem ./... > old.txt
$ git checkout 3717a577a65196747809a63ffe76c5ca6b0d88e8 && go test -run=NONE -bench=. -benchmem ./... > new.txt
$ benchcmp old.txt new.txt 
benchmark                                old ns/op       new ns/op      delta
Benchmark1000KB100Aliases-6              1056925022      1094599057     +3.56%
Benchmark1000KBDeeplyNestedSlices-6      282869888       7835556        -97.23%
Benchmark1000KBDeeplyNestedMaps-6        266289230       7375439        -97.23%
Benchmark1000KBDeeplyNestedIndents-6     4360666         4514662        +3.53%
Benchmark1000KB1000IndentLines-6         449900306       451543002      +0.37%
Benchmark1KBMaps-6                       599228          620644         +3.57%
Benchmark10KBMaps-6                      5801815         5892398        +1.56%
Benchmark100KBMaps-6                     53699570        57544454       +7.16%
Benchmark1000KBMaps-6                    513662800       538354297      +4.81%
BenchmarkDeepSlice-6                     46967064873     448771530      -99.04%
BenchmarkDeepFlow-6                      45121229024     648750899      -98.56%

benchmark                                old allocs     new allocs     delta
Benchmark1000KB100Aliases-6              5832441        5832438        -0.00%
Benchmark1000KBDeeplyNestedSlices-6      9068           9249           +2.00%
Benchmark1000KBDeeplyNestedMaps-6        9072           9252           +1.98%
Benchmark1000KBDeeplyNestedIndents-6     10082          10084          +0.02%
Benchmark1000KB1000IndentLines-6         4093516        4093517        +0.00%
Benchmark1KBMaps-6                       3126           3128           +0.06%
Benchmark10KBMaps-6                      30780          30782          +0.01%
Benchmark100KBMaps-6                     307269         307271         +0.00%
Benchmark1000KBMaps-6                    3072079        3072082        +0.00%
BenchmarkDeepSlice-6                     2048121        2048304        +0.01%
BenchmarkDeepFlow-6                      3334112        3334113        +0.00%

benchmark                                old bytes     new bytes     delta
Benchmark1000KB100Aliases-6              393120640     393118752     -0.00%
Benchmark1000KBDeeplyNestedSlices-6      4689806       4748760       +1.26%
Benchmark1000KBDeeplyNestedMaps-6        4690070       4749212       +1.26%
Benchmark1000KBDeeplyNestedIndents-6     2969933       2970002       +0.00%
Benchmark1000KB1000IndentLines-6         143718544     143718560     +0.00%
Benchmark1KBMaps-6                       218984        219112        +0.06%
Benchmark10KBMaps-6                      2178160       2178284       +0.01%
Benchmark100KBMaps-6                     22002813      22002938      +0.00%
Benchmark1000KBMaps-6                    220560496     220560768     +0.00%
BenchmarkDeepSlice-6                     120114824     120174234     +0.05%
BenchmarkDeepFlow-6                      190656952     190656984     +0.00%

```

