### PR TITLE
Stop checking uniqueKeys once we've found 10 errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -746,12 +746,16 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 	l := len(n.Content)
 	if d.uniqueKeys {
 		nerrs := len(d.terrors)
+	UNIQUECHECK:
 		for i := 0; i < l; i += 2 {
 			ni := n.Content[i]
 			for j := i + 2; j < l; j += 2 {
 				nj := n.Content[j]
 				if ni.Kind == nj.Kind && ni.Value == nj.Value {
 					d.terrors = append(d.terrors, fmt.Sprintf("line %d: mapping key %#v already defined at line %d", nj.Line, nj.Value, ni.Line))
+					if len(d.terrors)-nerrs >= 10 {
+						continue UNIQUECHECK
+					}
 				}
 			}
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -803,6 +803,19 @@ var unmarshalTests = []struct {
 		},
 	},
 
+	// Explicit mapping
+	{
+		`
+a:
+  b
+b:
+  ? a
+  : a`,
+		&M{"a": "b",
+			"b": M{
+				"a": "a",
+			}},
+	},
 }
 
 type M map[string]interface{}

--- a/limit_test.go
+++ b/limit_test.go
@@ -37,6 +37,8 @@ var limitTests = []struct {
 	{name: "10kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 10*1024/4-1) + `]`)},
 	{name: "100kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 100*1024/4-1) + `]`)},
 	{name: "1000kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-1) + `]`)},
+	{name: "1000kb slice nested at max-depth", data: []byte(strings.Repeat(`[`, 10000) + `1` + strings.Repeat(`,1`, 1000*1024/2-20000-1) + strings.Repeat(`]`, 10000))},
+	{name: "1000kb slice nested in maps at max-depth", data: []byte("{a,b:\n" + strings.Repeat(" {a,b:", 10000-2) + ` [1` + strings.Repeat(",1", 1000*1024/2-6*10000-1) + `]` + strings.Repeat(`}`, 10000-1))},
 }
 
 func (s *S) TestLimits(c *C) {
@@ -80,6 +82,14 @@ func Benchmark100KBMaps(b *testing.B) {
 }
 func Benchmark1000KBMaps(b *testing.B) {
 	benchmark(b, "1000kb of maps")
+}
+
+func BenchmarkDeepSlice(b *testing.B) {
+	benchmark(b, "1000kb slice nested at max-depth")
+}
+
+func BenchmarkDeepFlow(b *testing.B) {
+	benchmark(b, "1000kb slice nested in maps at max-depth")
 }
 
 func benchmark(b *testing.B, name string) {


### PR DESCRIPTION
This includes the benchmark test cases from https://github.com/go-yaml/yaml/pull/543.