### PR TITLE
Optimize cases with long potential simple_keys

### DIFF
--- a/limit_test.go
+++ b/limit_test.go
@@ -39,6 +39,7 @@ var limitTests = []struct {
 	{name: "1000kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-1) + `]`)},
 	{name: "1000kb slice nested at max-depth", data: []byte(strings.Repeat(`[`, 10000) + `1` + strings.Repeat(`,1`, 1000*1024/2-20000-1) + strings.Repeat(`]`, 10000))},
 	{name: "1000kb slice nested in maps at max-depth", data: []byte("{a,b:\n" + strings.Repeat(" {a,b:", 10000-2) + ` [1` + strings.Repeat(",1", 1000*1024/2-6*10000-1) + `]` + strings.Repeat(`}`, 10000-1))},
+	{name: "1000kb of 10000-nested lines", data: []byte(strings.Repeat(`- `+strings.Repeat(`[`, 10000)+strings.Repeat(`]`, 10000)+"\n", 1000*1024/20000))},
 }
 
 func (s *S) TestLimits(c *C) {
@@ -90,6 +91,10 @@ func BenchmarkDeepSlice(b *testing.B) {
 
 func BenchmarkDeepFlow(b *testing.B) {
 	benchmark(b, "1000kb slice nested in maps at max-depth")
+}
+
+func Benchmark1000KBMaxDepthNested(b *testing.B) {
+	benchmark(b, "1000kb of 10000-nested lines")
 }
 
 func benchmark(b *testing.B, name string) {

--- a/yamlh.go
+++ b/yamlh.go
@@ -577,8 +577,9 @@ type yaml_parser_t struct {
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed bool                // May a simple key occur at the current position?
-	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simple_key_allowed             bool                // May a simple key occur at the current position?
+	simple_keys                    []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_min_possible_index int
 
 	// Parser stuff
 

--- a/yamlh.go
+++ b/yamlh.go
@@ -577,9 +577,9 @@ type yaml_parser_t struct {
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed             bool                // May a simple key occur at the current position?
-	simple_keys                    []yaml_simple_key_t // The stack of simple keys.
-	simple_keys_min_possible_index int
+	simple_key_allowed bool                // May a simple key occur at the current position?
+	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_by_tok map[int]int         // possible simple_key indexes indexed by token_number
 
 	// Parser stuff
 


### PR DESCRIPTION
When we build up the simple_keys stack, we count on the (formerly named) staleness check to catch errors where a simple key is required but would be > 1024 chars or span lines. The previous simplification that searches the stack from the top can go 1024 keys deep before finding a "stale" key and stopping. I added a test that shows that this consumes ~3s per 1MB of document size.

I split that staleness check back out into a separate loop so that we don't unnecessarily re-process a bunch of keys just to get down to the ones that might have gone stale.
```
$ benchcmp old.txt new.txt
benchmark                                old ns/op      new ns/op     delta
Benchmark1000KB100Aliases-6              881167484      872120600     -1.03%
Benchmark1000KBDeeplyNestedSlices-6      48761251       5274819       -89.18%
Benchmark1000KBDeeplyNestedMaps-6        50438114       5292240       -89.51%
Benchmark1000KBDeeplyNestedIndents-6     4385726        4280545       -2.40%
Benchmark1000KB1000IndentLines-6         435702849      432047937     -0.84%
Benchmark1KBMaps-6                       574312         588420        +2.46%
Benchmark10KBMaps-6                      5727272        5895964       +2.95%
Benchmark100KBMaps-6                     52126341       52920733      +1.52%
Benchmark1000KBMaps-6                    484546095      474623653     -2.05%
BenchmarkDeepSlice-6                     455902294      397041567     -12.91%
BenchmarkDeepFlow-6                      399613786      407783513     +2.04%
Benchmark1000KBMaxDepthNested-6          2700904018     447527143     -83.43%

benchmark                                old allocs     new allocs     delta
Benchmark1000KB100Aliases-6              5832425        5832415        -0.00%
Benchmark1000KBDeeplyNestedSlices-6      9066           10081          +11.20%
Benchmark1000KBDeeplyNestedMaps-6        9071           10087          +11.20%
Benchmark1000KBDeeplyNestedIndents-6     10082          10082          +0.00%
Benchmark1000KB1000IndentLines-6         4093516        4093516        +0.00%
Benchmark1KBMaps-6                       3126           3126           +0.00%
Benchmark10KBMaps-6                      30780          30780          +0.00%
Benchmark100KBMaps-6                     307269         307269         +0.00%
Benchmark1000KBMaps-6                    3072079        3072079        +0.00%
BenchmarkDeepSlice-6                     2048121        2048112        -0.00%
BenchmarkDeepFlow-6                      1978104        1978103        -0.00%
Benchmark1000KBMaxDepthNested-6          4079998        4079989        -0.00%

benchmark                                old bytes     new bytes     delta
Benchmark1000KB100Aliases-6              393118344     392792852     -0.08%
Benchmark1000KBDeeplyNestedSlices-6      4689465       4576336       -2.41%
Benchmark1000KBDeeplyNestedMaps-6        4689831       4577450       -2.40%
Benchmark1000KBDeeplyNestedIndents-6     2969924       2969913       -0.00%
Benchmark1000KB1000IndentLines-6         143718512     143718512     +0.00%
Benchmark1KBMaps-6                       218984        218984        +0.00%
Benchmark10KBMaps-6                      2178155       2178154       -0.00%
Benchmark100KBMaps-6                     22002796      22002807      +0.00%
Benchmark1000KBMaps-6                    220560496     220560496     +0.00%
BenchmarkDeepSlice-6                     120114888     119789000     -0.27%
BenchmarkDeepFlow-6                      115058032     115056832     -0.00%
Benchmark1000KBMaxDepthNested-6          146582888     146257064     -0.22%
```