### PR TITLE
add struct info options

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -246,10 +246,36 @@ var (
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )
 
-func newDecoder(strict bool) *decoder {
-	d := &decoder{mapType: defaultMapType, strict: strict, structParser: DefaultStructParser}
+func newDecoder(opt ...DecoderOption) *decoder {
+	d := &decoder{mapType: defaultMapType, structParser: DefaultStructParser}
+	for _, o := range opt {
+		o(d)
+	}
 	d.aliases = make(map[*node]bool)
 	return d
+}
+
+type DecoderOption func(*decoder)
+
+// WithStrictFields makes the decoder to report an error for any fields that are
+// found in the data that do not have corresponding struct members,
+// or mapping keys that are duplicates
+func DecoderWithStrictFields() DecoderOption {
+	return func(d *decoder) {
+		d.strict = true
+	}
+}
+
+func DecoderWithFieldNameMarshaler(f FieldNameMarshaler) DecoderOption {
+	return func(d *decoder) {
+		d.structParser.nameMarshaler = f
+	}
+}
+
+func DecoderWithStructTagParser(f StructTagParser) DecoderOption {
+	return func(d *decoder) {
+		d.structParser.tagParser = f
+	}
 }
 
 func (d *decoder) terror(n *node, tag string, out reflect.Value) {

--- a/decode.go
+++ b/decode.go
@@ -233,6 +233,8 @@ type decoder struct {
 	decodeCount int
 	aliasCount  int
 	aliasDepth  int
+
+	structParser StructParser
 }
 
 var (
@@ -245,7 +247,7 @@ var (
 )
 
 func newDecoder(strict bool) *decoder {
-	d := &decoder{mapType: defaultMapType, strict: strict}
+	d := &decoder{mapType: defaultMapType, strict: strict, structParser: DefaultStructParser}
 	d.aliases = make(map[*node]bool)
 	return d
 }
@@ -722,7 +724,7 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 }
 
 func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
-	sinfo, err := getStructInfo(out.Type())
+	sinfo, err := d.structParser.GetStructInfo(out.Type())
 	if err != nil {
 		panic(err)
 	}

--- a/encode.go
+++ b/encode.go
@@ -60,7 +60,7 @@ func newEncoderWithWriter(w io.Writer, opt ...EncoderOption) *encoder {
 	return e
 }
 
-type EncoderOption = func(*encoder)
+type EncoderOption func(*encoder)
 
 func WithFieldNameMarshaler(f FieldNameMarshaler) EncoderOption {
 	return func(e *encoder) {

--- a/encode.go
+++ b/encode.go
@@ -62,13 +62,13 @@ func newEncoderWithWriter(w io.Writer, opt ...EncoderOption) *encoder {
 
 type EncoderOption func(*encoder)
 
-func WithFieldNameMarshaler(f FieldNameMarshaler) EncoderOption {
+func EncoderWithFieldNameMarshaler(f FieldNameMarshaler) EncoderOption {
 	return func(e *encoder) {
 		e.structParser.nameMarshaler = f
 	}
 }
 
-func WithStructTagParser(f StructTagParser) EncoderOption {
+func EncoderWithStructTagParser(f StructTagParser) EncoderOption {
 	return func(e *encoder) {
 		e.structParser.tagParser = f
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v2"
+module gopkg.in/yaml.v2
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yaml.go
+++ b/yaml.go
@@ -307,8 +307,8 @@ type fieldInfo struct {
 var structMap = make(map[reflect.Type]*structInfo)
 var fieldMapMutex sync.RWMutex
 
-type StructTagParser = func(reflect.StructTag) (tag string, flags []string)
-type FieldNameMarshaler = func(reflect.StructField) string
+type StructTagParser func(reflect.StructTag) (tag string, flags []string)
+type FieldNameMarshaler func(reflect.StructField) string
 
 func DefaultStructTagParser(t reflect.StructTag) (tag string, flags []string) {
 	tag = t.Get("yaml")

--- a/yaml.go
+++ b/yaml.go
@@ -77,8 +77,8 @@ type Marshaler interface {
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
 //
-func Unmarshal(in []byte, out interface{}) (err error) {
-	return unmarshal(in, out, false)
+func Unmarshal(in []byte, out interface{}, opt ...DecoderOption) (err error) {
+	return unmarshal(in, out, opt...)
 }
 
 // UnmarshalStrict is like Unmarshal except that any fields that are found
@@ -86,7 +86,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 // keys that are duplicates, will result in
 // an error.
 func UnmarshalStrict(in []byte, out interface{}) (err error) {
-	return unmarshal(in, out, true)
+	return unmarshal(in, out, DecoderWithStrictFields())
 }
 
 // A Decoder reads and decodes YAML values from an input stream.
@@ -117,7 +117,7 @@ func (dec *Decoder) SetStrict(strict bool) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (dec *Decoder) Decode(v interface{}) (err error) {
-	d := newDecoder(dec.strict)
+	d := newDecoder(DecoderWithStrictFields())
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -134,9 +134,9 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	return nil
 }
 
-func unmarshal(in []byte, out interface{}, strict bool) (err error) {
+func unmarshal(in []byte, out interface{}, opt ...DecoderOption) (err error) {
 	defer handleErr(&err)
-	d := newDecoder(strict)
+	d := newDecoder(opt...)
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()


### PR DESCRIPTION
I have drafted injection of struct info options to make them configurable. Are you okay with this approach?

I have tested marshaling/unmarshaling as follows:
```go
func MustParseConfig(s string) *Config { 
    var cfg Config                                                                                 
    err := yaml.Unmarshal([]byte(s), &cfg, yaml.DecoderWithFieldNameMarshaler(FieldNameMarshaler))
    if err != nil {
        panic(fmt.Errorf("invalid config: %v", err))                                         
    }                                                                                               
    return &cfg                                                                                     
}                                                                                                   
                                                                                                    
func (c *Config) String() string {                                                                  
    b, _ := yaml.Marshal(c, yaml.EncoderWithFieldNameMarshaler(FieldNameMarshaler))                        
    return string(b)                                                                                
}                                                                                                   
                                                                                                    
func FieldNameMarshaler(f reflect.StructField) string {                                             
    return f.Name
}
```