### PR TITLE
Feature (v3): compatible with only json-tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yaml.go
+++ b/yaml.go
@@ -339,7 +339,7 @@ const (
 //             Address yaml.Node
 //     }
 //     err := yaml.Unmarshal(data, &person)
-// 
+//
 // Or by itself:
 //
 //     var person Node
@@ -349,7 +349,7 @@ type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -510,9 +510,17 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 		info := fieldInfo{Num: i}
 
 		tag := field.Tag.Get("yaml")
-		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
+		if tag == "" && !strings.Contains(string(field.Tag), ":") {
 			tag = string(field.Tag)
 		}
+		// compatible with only json-tag
+		if tag == "" {
+			tag = field.Tag.Get("json")
+			if tag == "" && !strings.Contains(string(field.Tag), ":") {
+				tag = string(field.Tag)
+			}
+		}
+
 		if tag == "-" {
 			continue
 		}


### PR DESCRIPTION
In some scenarios, you cannot manually add the `yaml` tag, such as grpc's automatic code generation. Such as:
```go
// Code generated by protoc-gen-go. DO NOT EDIT.
//...
type Metadata struct {
	Name                 string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
        //...
}
```

work flow：yaml(go struct) -> grpc -> server

