### PR TITLE
Fix typo in Decoder docstring.

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
 
-// A Decorder reads and decodes YAML values from an input stream.
+// A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	parser      *parser
 	knownFields bool


### PR DESCRIPTION
I just realized this small typo while I was skimming through the documentation. I could've opened an issue but thought it'd be a hassle.