### PR TITLE
Allow Custom Marshalers to use flow style marshaling

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -132,6 +132,17 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 			return
 		}
 		in = reflect.ValueOf(v)
+	case FlowMarshaler:
+		e.flow = true
+		v, err := m.FlowMarshalYAML()
+		if err != nil {
+			fail(err)
+		}
+		if v == nil {
+			e.nilv()
+			return
+		}
+		in = reflect.ValueOf(v)
 	case encoding.TextMarshaler:
 		text, err := m.MarshalText()
 		if err != nil {

--- a/yaml.go
+++ b/yaml.go
@@ -43,6 +43,15 @@ type Marshaler interface {
 	MarshalYAML() (interface{}, error)
 }
 
+// The FlowMarshaler interface may be implemented by types to customize their
+// behavior when being unmarshaled from a YAML document, while also having flow
+// style marshalling. The FlowMarshalYAML method receives a function that may be
+// called to unmarshal the original YAML value into a field or variable. It is
+// safe to call the unmarshal function parameter more than once if necessary.
+type FlowMarshaler interface {
+	FlowMarshalYAML() (interface{}, error)
+}
+
 // Unmarshal decodes the first document found within the in byte slice
 // and assigns decoded values into the out value.
 //


### PR DESCRIPTION
My main goal is to allow a field of type `[][]string` to specify that the outer array is normal and the inner array is flow. With this FlowMarshaler it will become possible to accomplish that, as shown in the test case.