### PR TITLE
Feature (v2): set the default line length to infinity (-1)

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -86,6 +86,7 @@ func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
 		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
 		events:     make([]yaml_event_t, 0, initial_queue_size),
+		best_width: -1,
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -397,6 +397,11 @@ var marshalTests = []struct {
 		map[string]interface{}{"a": jsonNumberT("bogus")},
 		"a: bogus\n",
 	},
+	// Ensure that strings do not wrap
+	{
+		map[string]string{"a": "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 "},
+		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {


### PR DESCRIPTION
as suggested here: https://github.com/go-yaml/yaml/issues/166#issuecomment-555447882