### PR TITLE
Marshal YAML 1.1 bool-like to strings

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -176,6 +176,12 @@ var marshalTests = []struct {
 	}, {
 		&struct{ A bool }{true},
 		"a: true\n",
+	}, {
+		&struct{ A string }{"true"},
+		"a: \"true\"\n",
+	}, {
+		&struct{ A string }{"off"},
+		"a: \"off\"\n",
 	},
 
 	// Conditional flag


### PR DESCRIPTION
I'm not 100% sure if this is the right place to do this, it works, and
is somewhat in the spirit of decode.go.  I've put an explanation of the
reasoning in the commit, not sure if you'd rather have something in the README.