### PR TITLE
Add go1.14 into travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
     - "1.11.x"
     - "1.12.x"
     - "1.13.x"
+    - "1.14.x"
     - "tip"
 
 go_import_path: gopkg.in/yaml.v3


### PR DESCRIPTION
The latest go1.14 is v1.14.1, it would be good to add it as cross-check as part of travis build.

