### PR TITLE
fix wrong encoding utf characters in comments 注释中文乱码修复

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -765,6 +765,23 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"# 一\n# 二\ntrue # 三\n# 四\n# 五\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   3,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:        yaml.ScalarNode,
+				Value:       "true",
+				Tag:         "!!bool",
+				Line:        3,
+				Column:      1,
+				HeadComment: "# 一\n# 二",
+				LineComment: "# 三",
+				FootComment: "# 四\n# 五",
+			}},
+		},
+	}, {
 
 		"[decode]\n# One\n\n# Two\n\n# Three\ntrue # Four\n# Five\n\n# Six\n\n# Seven\n",
 		yaml.Node{
@@ -950,9 +967,9 @@ var nodeTests = []struct {
 	}, {
 		"- la # IA\n- lb # IB\n- lc # IC\n",
 		yaml.Node{
-			Kind:        yaml.DocumentNode,
-			Line:        1,
-			Column:      1,
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
 			Content: []*yaml.Node{{
 				Kind:   yaml.SequenceNode,
 				Tag:    "!!seq",
@@ -985,9 +1002,9 @@ var nodeTests = []struct {
 	}, {
 		"# DH1\n\n# HL1\n- - la\n  # HB1\n  - lb\n",
 		yaml.Node{
-			Kind:   yaml.DocumentNode,
-			Line:   4,
-			Column: 1,
+			Kind:        yaml.DocumentNode,
+			Line:        4,
+			Column:      1,
 			HeadComment: "# DH1",
 			Content: []*yaml.Node{{
 				Kind:   yaml.SequenceNode,
@@ -1020,9 +1037,9 @@ var nodeTests = []struct {
 	}, {
 		"# DH1\n\n# HL1\n- # HA1\n  - la\n  # HB1\n  - lb\n",
 		yaml.Node{
-			Kind:   yaml.DocumentNode,
-			Line:   4,
-			Column: 1,
+			Kind:        yaml.DocumentNode,
+			Line:        4,
+			Column:      1,
 			HeadComment: "# DH1",
 			Content: []*yaml.Node{{
 				Kind:   yaml.SequenceNode,
@@ -1036,11 +1053,11 @@ var nodeTests = []struct {
 					Column:      3,
 					HeadComment: "# HL1",
 					Content: []*yaml.Node{{
-						Kind:   yaml.ScalarNode,
-						Tag:    "!!str",
-						Line:   5,
-						Column: 5,
-						Value:  "la",
+						Kind:        yaml.ScalarNode,
+						Tag:         "!!str",
+						Line:        5,
+						Column:      5,
+						Value:       "la",
 						HeadComment: "# HA1",
 					}, {
 						Kind:        yaml.ScalarNode,
@@ -1056,9 +1073,9 @@ var nodeTests = []struct {
 	}, {
 		"[decode]# DH1\n\n# HL1\n- # HA1\n\n  - la\n  # HB1\n  - lb\n",
 		yaml.Node{
-			Kind:   yaml.DocumentNode,
-			Line:   4,
-			Column: 1,
+			Kind:        yaml.DocumentNode,
+			Line:        4,
+			Column:      1,
 			HeadComment: "# DH1",
 			Content: []*yaml.Node{{
 				Kind:   yaml.SequenceNode,

--- a/scannerc.go
+++ b/scannerc.go
@@ -2843,7 +2843,7 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 			continue
 		}
 		if parser.buffer[parser.buffer_pos+peek] == '#' {
-			seen := parser.mark.index+peek
+			seen := parser.mark.index + peek
 			for {
 				if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 					return false
@@ -2861,7 +2861,11 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 						if len(text) == 0 {
 							start_mark = parser.mark
 						}
-						text = append(text, parser.buffer[parser.buffer_pos])
+						if w := width(parser.buffer[parser.buffer_pos]); w > 1 {
+							text = append(text, parser.buffer[parser.buffer_pos:parser.buffer_pos+w]...)
+						} else {
+							text = append(text, parser.buffer[parser.buffer_pos])
+						}
 					}
 					skip(parser)
 				}
@@ -2873,7 +2877,7 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 		parser.comments = append(parser.comments, yaml_comment_t{
 			token_mark: token_mark,
 			start_mark: start_mark,
-			line: text,
+			line:       text,
 		})
 	}
 	return true
@@ -2903,7 +2907,7 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 	// the foot is the line below it.
 	var foot_line = -1
 	if scan_mark.line > 0 {
-		foot_line = parser.mark.line-parser.newlines+1
+		foot_line = parser.mark.line - parser.newlines + 1
 		if parser.newlines == 0 && parser.mark.column > 1 {
 			foot_line++
 		}
@@ -2986,7 +2990,7 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 		recent_empty = false
 
 		// Consume until after the consumed comment line.
-		seen := parser.mark.index+peek
+		seen := parser.mark.index + peek
 		for {
 			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 				return false
@@ -3001,7 +3005,11 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 				skip_line(parser)
 			} else {
 				if parser.mark.index >= seen {
-					text = append(text, parser.buffer[parser.buffer_pos])
+					if w := width(parser.buffer[parser.buffer_pos]); w > 1 {
+						text = append(text, parser.buffer[parser.buffer_pos:parser.buffer_pos+w]...)
+					} else {
+						text = append(text, parser.buffer[parser.buffer_pos])
+					}
 				}
 				skip(parser)
 			}


### PR DESCRIPTION
this will fix https://github.com/go-yaml/yaml/issues/578 problem

It happens when your language was endoce in utf8 with more than one byte.
It was caused by only add the first byte when parsing multi byte utf8 word.
  
node_test case:
```go
{
"# 一\n# 二\ntrue # 三\n# 四\n# 五\n",
yaml.Node{
	Kind:   yaml.DocumentNode,
		Line:   3,
		Column: 1,
		Content: []*yaml.Node{{
			Kind:        yaml.ScalarNode,
			Value:       "true",
			Tag:         "!!bool",
			Line:        3,
			Column:      1,
			HeadComment: "# 一\n# 二",
			LineComment: "# 三",
			FootComment: "# 四\n# 五",
		}},
	},
}
```
test failed output:
```bash
/usr/local/go/bin/go test -c -o /tmp/___S_TestNodeRoundtrip_in_gopkg_in_yaml_v3 gopkg.in/yaml.v3 #gosetup
/tmp/___S_TestNodeRoundtrip_in_gopkg_in_yaml_v3 -test.v -check.f ^TestNodeRoundtrip$ -check.vv #gosetup
test 0: "# 一\n# 二\ntrue # 三\n# 四\n# 五\n"
  expected comments:
    <DOC> 
      <true> "# 一\n# 二" / "# 三" / "# 四\n# 五"

  obtained comments:
    <DOC> 
      <true> "# \xe4\n# \xe4" / "# \xe4" / "# \xe5\n# \xe4"


c.Assert(node, DeepEquals, item.node)
Expected :yaml.Node = yaml.Node{Kind:0x1, Style:0x0, Tag:"", Value:"", Anchor:"", Alias:(*yaml.Node)(nil), Content:[]*yaml.Node{(*yaml.Node)(0x803480)}, HeadComment:"", LineComment:"", FootComment:"", Line:3, Column:1}
Actual   :yaml.Node = yaml.Node{Kind:0x1, Style:0x0, Tag:"", Value:"", Anchor:"", Alias:(*yaml.Node)(nil), Content:[]*yaml.Node{(*yaml.Node)(0xc0000a2820)}, HeadComment:"", LineComment:"", FootComment:"", Line:3, Column:1}
<Click to see difference>

node_test.go:2279

OOPS: 0 passed, 1 FAILED
--- FAIL: Test (0.00s)
=== RUN   ExampleUnmarshal_embedded
--- PASS: ExampleUnmarshal_embedded (0.00s)
```
after this fix, the test will pass