### PR TITLE
The configuration value of string type supports the syntax of environment variables.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -432,6 +432,9 @@ func (d *decoder) scalar(n *node, out reflect.Value) bool {
 		}
 		return true
 	}
+	if str, ok := resolved.(string); ok {
+		resolved = expandValueEnv(str)
+	}
 	if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
 		// We've resolved to exactly the type we want, so use that.
 		out.Set(resolvedv)

--- a/expand.go
+++ b/expand.go
@@ -1,0 +1,43 @@
+package yaml
+
+import (
+	"os"
+)
+
+// if string like ${NAME||archaius}
+// will query environment variable for ${NAME}
+// if environment variable is "" return default string `archaius`
+func expandValueEnv(value string) (realValue string) {
+	realValue = value
+
+	vLen := len(value)
+	// 3 = ${}
+	if vLen < 3 {
+		return
+	}
+	// Need start with "${" and end with "}", then return.
+	if value[0] != '$' || value[1] != '{' || value[vLen-1] != '}' {
+		return
+	}
+
+	key := ""
+	defaultV := ""
+	// value start with "${"
+	for i := 2; i < vLen; i++ {
+		if value[i] == '|' && (i+1 < vLen && value[i+1] == '|') {
+			key = value[2:i]
+			defaultV = value[i+2 : vLen-1] // other string is default value.
+			break
+		} else if value[i] == '}' {
+			key = value[2:i]
+			break
+		}
+	}
+
+	realValue = os.Getenv(key)
+	if realValue == "" {
+		realValue = defaultV
+	}
+
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module "gopkg.in/yaml.v2"
+module github.com/yankooo/yaml
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/yankooo/yaml
+module "gopkg.in/yaml.v2"
 
-require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)


### PR DESCRIPTION
The configuration value of the string type supports the following syntax :

demo.yaml :
``` yaml
gopath: ${GO||/usr/local/go}
```
if environment variable `${Go}` isn't setting,  return default value `/usr/local/go` .