### PR TITLE
support convert from yaml.Node

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -119,6 +119,9 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 	case *Node:
 		e.nodev(in)
 		return
+	case Node:
+		e.nodev(in.Addr())
+		return
 	case time.Time:
 		e.timev(tag, in)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.14
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
marshal not convert from yaml.Node just convert *yaml.Node
so encode.go 122 add :
	case Node:
		e.nodev(in.Addr())
		return

just work.