### PR TITLE
Improve sorting consistency of map keys

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -580,8 +580,8 @@ func (s *S) TestSortedOutput(c *C) {
 		"a/11",
 		"a/0012",
 		"a/100",
-		"a~10",
 		"ab/1",
+		"a~10",
 		"b/1",
 		"b/01",
 		"b/2",
@@ -598,6 +598,8 @@ func (s *S) TestSortedOutput(c *C) {
 		"d7abc",
 		"d12",
 		"d12a",
+		"e11",
+		"e1a",
 	}
 	m := make(map[interface{}]int)
 	for _, k := range order {

--- a/sorter.go
+++ b/sorter.go
@@ -43,12 +43,10 @@ func (l keyList) Less(i, j int) bool {
 		}
 		al := unicode.IsLetter(ar[i])
 		bl := unicode.IsLetter(br[i])
-		if al && bl {
+		if al || bl {
 			return ar[i] < br[i]
 		}
-		if al || bl {
-			return bl
-		}
+
 		var ai, bi int
 		var an, bn int64
 		if ar[i] == '0' || br[i] == '0' {


### PR DESCRIPTION
This PR would improve consistency when marshaling maps. The problem occurs when comparing letters to other characters, ex. `"a10"` and `"a1a"`. Currently, the result would be non-deterministic because of https://github.com/go-yaml/yaml/blob/0b1645d91e851e735d3e23330303ce81f70adbe3/sorter.go#L49-L51

if `"a10"` happens to be assigned to `ar` and `"a1a"` to `br`, that code would return `true`, while if the assignment was the other way around, it would return `false`.