### PR TITLE
Allow users to hook into the encoder

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -113,6 +113,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 				e.nilv()
 				return
 			}
+			in = reflect.ValueOf(out)
 			iface = out
 		}
 	}

--- a/yaml.go
+++ b/yaml.go
@@ -220,6 +220,13 @@ func NewEncoder(w io.Writer) *Encoder {
 	}
 }
 
+// SetHook adds a marshaling hook into the Encoder. The function f will be
+// called for each node to be marshalled. f must return true if the hook
+// "handled" the node, in which case the output value will be used.
+func (e *Encoder) SetHook(hook func(in interface{}) (ok bool, out interface{}, err error)) {
+	e.encoder.hook = hook
+}
+
 // Encode writes the YAML encoding of v to the stream.
 // If multiple items are encoded to the stream, the
 // second and subsequent document will be preceded


### PR DESCRIPTION
Users of a package may want to marshal a type that implements yaml.Marshaler without calling that specific type's `yaml.MarshalYAML` method. 

This PR allows for a generic hook function to be called for each object, allowing for users to control which types are marshaled and optionally bypassing `MarshalYAML` for a specific type.  