### PR TITLE
support include tag to split a big yaml file 

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,5 +1,5 @@
 //
-// Copyrightunmarsah (c) 2011-2019 Canonical Ltd
+// Copyright (c) 2011-2019 Canonical Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -316,11 +316,12 @@ type decoder struct {
 	stringMapType  reflect.Type
 	generalMapType reflect.Type
 
-	knownFields bool
-	uniqueKeys  bool
-	decodeCount int
-	aliasCount  int
-	aliasDepth  int
+	knownFields        bool
+	supportIncludeFile bool
+	uniqueKeys         bool
+	decodeCount        int
+	aliasCount         int
+	aliasDepth         int
 }
 
 var (
@@ -578,7 +579,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		return d.null(out)
 	}
 
-	if tag == "!!include" {
+	if d.supportIncludeFile && tag == "!!include" {
 		str := resolved.(string)
 		f, err := os.Open(str)
 		if err != nil {

--- a/decode.go
+++ b/decode.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011-2019 Canonical Ltd
+// Copyrightunmarsah (c) 2011-2019 Canonical Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -576,6 +577,18 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	if resolved == nil {
 		return d.null(out)
 	}
+
+	if tag == "!!include" {
+		str := resolved.(string)
+		f, err := os.Open(str)
+		if err != nil {
+			failf("open file error %+v", err)
+		}
+		parser := newParserFromReader(f)
+		node := parser.parse()
+		return d.unmarshal(node, out)
+	}
+
 	if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
 		// We've resolved to exactly the type we want, so use that.
 		out.Set(resolvedv)

--- a/yaml.go
+++ b/yaml.go
@@ -93,6 +93,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 type Decoder struct {
 	parser      *parser
 	knownFields bool
+	supportIncludeFile bool
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -111,6 +112,11 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
+// SupportIncludeFile to support !!include tag’s for file import
+func (dec *Decoder) SupportIncludeFile(enable bool) {
+	dec.supportIncludeFile = enable
+}
+
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v.
 //
@@ -119,6 +125,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
+	d.supportIncludeFile = dec.supportIncludeFile
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -363,7 +370,7 @@ const (
 //             Address yaml.Node
 //     }
 //     err := yaml.Unmarshal(data, &person)
-// 
+//
 // Or by itself:
 //
 //     var person Node


### PR DESCRIPTION
Here I Provied a tag `!!include` To Include another file when decode yaml
This can be reduce the yaml file size, and impove yaml file readaility when deal with big yaml config file

EG:

```yaml
%yaml foo.yml 
---
c: !!include bar.yml
```

```yaml
%yaml bar.yml
---
a: 1
b: 2
```

And You go program will be like this 

```golang

type Res struct {
	C struct {
		A int
		B int
	} `yaml::"c"`
}

func main() {
	f, err := os.Open("foo.yml")
	if err != nil {
		panic(err)
	}
	d := yaml.NewDecoder(f)
	d.SupportIncludeFile(true)
	var res Res
	if err := d.Decode(&res); err != nil {
		panic(err)
	}
	fmt.Printf("res is %+v", res)
}

```

