### PR TITLE
Change the yaml bomb prevention counters to uint

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -230,9 +230,9 @@ type decoder struct {
 	terrors []string
 	strict  bool
 
-	decodeCount int
-	aliasCount  int
-	aliasDepth  int
+	decodeCount uint
+	aliasCount  uint
+	aliasDepth  uint
 }
 
 var (
@@ -331,7 +331,7 @@ const (
 	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
 )
 
-func allowedAliasRatio(decodeCount int) float64 {
+func allowedAliasRatio(decodeCount uint) float64 {
 	switch {
 	case decodeCount <= alias_ratio_range_low:
 		// allow 99% to come from alias expansion for small-to-medium documents


### PR DESCRIPTION
This commit changes the decoder's `decodeCount`, `aliasCount` and `aliasDepth` fields into `uint`.

Those fields were first introduced in https://github.com/go-yaml/yaml/commit/bb4e33bf68bf89cad44d386192cbed201f35b241 in order to detect and protect against yaml bomb scenarios.

However, since those variables are _counters_, there is no reason for them to hold a negative value. Also, the checks performed on them:
```go
	if d.aliasCount > 100 && d.decodeCount > 1000 && float64(d.aliasCount)/float64(d.decodeCount) > allowedAliasRatio(d.decodeCount) {
```
could theoretically by bypassed if the `decodeCount` variable would overflow to a negative value.

I think this scenario is rather very unlikely or even impossible to happen, as `int` is `int64` on 64-bit binaries and `int32` on 32-bit ones. In both cases, overflowing the counter would rather already require a payload that would cause an out-of-memory issue.