### PR TITLE
Adding EncodeWithComments function

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -270,6 +270,23 @@ func (n *Node) Encode(v interface{}) (err error) {
 	return nil
 }
 
+// EncodeWithComments encodes but allows comments to remain.
+//
+// See documentation for Encode
+func (n *Node) EncodeWithComments(v interface{}) (err error) {
+	defer handleErr(&err)
+	e := newEncoder()
+	defer e.destroy()
+	e.marshalDoc("", reflect.ValueOf(v))
+	e.finish()
+	p := newParser(e.out)
+	p.textless = false // This is what differs between Encode and EncodeWithComments
+	defer p.destroy()
+	doc := p.parse()
+	*n = *doc.Content[0]
+	return nil
+}
+
 // SetIndent changes the used indentation used when encoding.
 func (e *Encoder) SetIndent(spaces int) {
 	if spaces < 0 {


### PR DESCRIPTION
`node.Encode()` does not add comments by default. This is because the parser has `p.textless = true` set which causes this if clause to be skipped and not add comments:
```
	if !p.textless {
		n.Line = p.event.start_mark.line + 1
		n.Column = p.event.start_mark.column + 1
		n.HeadComment = string(p.event.head_comment)
		n.LineComment = string(p.event.line_comment)
		n.FootComment = string(p.event.foot_comment)
	}
```

Is there a better way to update values in `yaml.Node` that I should be using instead of `node.Encode`?

If `node.Encode` is the correct function to use, there are multiple ways to fix this to allow comments to remain. I've included what I'm using in my fork but happy to switch to another strategy.

IE:
- Passing in an options struct to control `textless` (and other future options if a need arises)
- Moving functionality from `Encode` to a common `encode` that both `Encode` and `EncodeWithComments` can both reference. This would keep `EncodeWithComments` from duplicating most of the lines from the existing `Encode` function.