### PR TITLE
Revert "Set the default line length to infinity (-1) (#571)"

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -86,7 +86,6 @@ func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
 		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
 		events:     make([]yaml_event_t, 0, initial_queue_size),
-		best_width: -1,
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -397,11 +397,6 @@ var marshalTests = []struct {
 		map[string]interface{}{"a": jsonNumberT("bogus")},
 		"a: bogus\n",
 	},
-	// Ensure that strings do not wrap
-	{
-		map[string]string{"a": "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 "},
-		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n",
-	},
 }
 
 func (s *S) TestMarshal(c *C) {


### PR DESCRIPTION
This reverts commit 0b1645d91e851e735d3e23330303ce81f70adbe3.

Hi,
At kubernetes, we are having a hard time with this change as it changes default behavior with no recourse to setting a custom width (to what it was before). Please see the following scenarios we hit recently:
- https://github.com/kubernetes/kubernetes/pull/95571#issuecomment-708796327
- https://github.com/kubernetes/kubernetes/pull/96425#issuecomment-725858135

Signed-off-by: Davanum Srinivas <davanum@gmail.com>