### PR TITLE
fixed behavior when parsing null values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -548,11 +548,8 @@ func resetMap(out reflect.Value) {
 
 func (d *decoder) null(out reflect.Value) bool {
 	if out.CanAddr() {
-		switch out.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
-			out.Set(reflect.Zero(out.Type()))
-			return true
-		}
+		out.Set(reflect.Zero(out.Type()))
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
I've tried to solve the issue (#681)  when parsing null values, removed type checking in switch block and made a default value for all scalar types.
I'll be glad for any opinion