### PR TITLE
[v3] Improve comment handling

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -202,17 +202,15 @@ func (p *parser) parseChild(parent *Node) *Node {
 }
 
 func (p *parser) document() *Node {
+	n := p.node(DocumentNode, "", "", "")
+	p.doc = n
 	if !p.event.implicit && len(p.event.head_comment) > 0 {
 		// This comment belongs to **before** the document event
-		n := p.node(DocumentNode, "", "", "")
-		// (1, 1) is not fully correct, but close enough
 		n.Line = 1
 		n.Column = 1
 		p.event.head_comment = nil
 		return n
 	}
-	n := p.node(DocumentNode, "", "", "")
-	p.doc = n
 	p.expect(yaml_DOCUMENT_START_EVENT)
 	p.parseChild(n)
 	if p.peek() == yaml_DOCUMENT_END_EVENT {

--- a/decode.go
+++ b/decode.go
@@ -202,6 +202,15 @@ func (p *parser) parseChild(parent *Node) *Node {
 }
 
 func (p *parser) document() *Node {
+	if !p.event.implicit && len(p.event.head_comment) > 0 {
+		// This comment belongs to **before** the document event
+		n := p.node(DocumentNode, "", "", "")
+		// (1, 1) is not fully correct, but close enough
+		n.Line = 1
+		n.Column = 1
+		p.event.head_comment = nil
+		return n
+	}
 	n := p.node(DocumentNode, "", "", "")
 	p.doc = n
 	p.expect(yaml_DOCUMENT_START_EVENT)

--- a/emitterc.go
+++ b/emitterc.go
@@ -451,7 +451,6 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 			if !yaml_emitter_process_head_comment(emitter) {
 				return false
 			}
-			// Do not add newline if the document is empty
 			if !isEmpty && !put_break(emitter) {
 				return false
 			}

--- a/emitterc.go
+++ b/emitterc.go
@@ -359,6 +359,7 @@ func yaml_emitter_emit_stream_start(emitter *yaml_emitter_t, event *yaml_event_t
 func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event_t, first bool) bool {
 
 	if event.typ == yaml_DOCUMENT_START_EVENT {
+		isEmpty := emitter.events[emitter.events_head + 1].typ == yaml_DOCUMENT_END_EVENT
 
 		if event.version_directive != nil {
 			if !yaml_emitter_analyze_version_directive(emitter, event.version_directive) {
@@ -456,6 +457,9 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 		}
 
 		emitter.state = yaml_EMIT_DOCUMENT_CONTENT_STATE
+		if isEmpty {
+			emitter.state = yaml_EMIT_DOCUMENT_END_STATE
+		}
 		return true
 	}
 

--- a/emitterc.go
+++ b/emitterc.go
@@ -451,7 +451,8 @@ func yaml_emitter_emit_document_start(emitter *yaml_emitter_t, event *yaml_event
 			if !yaml_emitter_process_head_comment(emitter) {
 				return false
 			}
-			if !put_break(emitter) {
+			// Do not add newline if the document is empty
+			if !isEmpty && !put_break(emitter) {
 				return false
 			}
 		}

--- a/parserc.go
+++ b/parserc.go
@@ -893,7 +893,17 @@ func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_ev
 	if token.typ == yaml_VALUE_TOKEN {
 		mark := token.end_mark
 		skip_token(parser)
-		// Move foot comment to head comment
+		// Move foot comment to head comment. This prevents that in some cases, comments
+		// in maps are moved to the wrong place. In the following map:
+		//
+		//     a:
+		//       b:
+		//         # comment followed by newline
+		//
+		//         c: d
+		//
+		// (the newline between the comment and the next line is essential!)
+		// the comment ends up as the foot comment of `c`, which is obviously wrong.
 		if len(parser.foot_comment) > 0 {
 			if len(parser.head_comment) > 0 {
 				parser.head_comment = append(parser.head_comment, '\n')

--- a/parserc.go
+++ b/parserc.go
@@ -890,6 +890,14 @@ func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_ev
 	if token.typ == yaml_VALUE_TOKEN {
 		mark := token.end_mark
 		skip_token(parser)
+		// Move foot comment to head comment
+		if len(parser.foot_comment) > 0 {
+			if len(parser.head_comment) > 0 {
+				parser.head_comment = append(parser.head_comment, '\n')
+			}
+			parser.head_comment = append(parser.head_comment, parser.foot_comment...)
+			parser.foot_comment = nil
+		}
 		token = peek_token(parser)
 		if token == nil {
 			return false

--- a/parserc.go
+++ b/parserc.go
@@ -305,6 +305,7 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 			typ:        yaml_DOCUMENT_START_EVENT,
 			start_mark: token.start_mark,
 			end_mark:   token.end_mark,
+			implicit:   true,
 
 			head_comment: head_comment,
 		}
@@ -338,6 +339,7 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 			tag_directives:    tag_directives,
 			implicit:          false,
 		}
+		yaml_parser_set_event_comments(parser, event)
 		skip_token(parser)
 
 	} else {

--- a/parserc.go
+++ b/parserc.go
@@ -348,6 +348,7 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 			start_mark: token.start_mark,
 			end_mark:   token.end_mark,
 		}
+		yaml_parser_set_event_comments(parser, event)
 		skip_token(parser)
 	}
 

--- a/yaml.go
+++ b/yaml.go
@@ -120,7 +120,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
 	defer handleErr(&err)
-	node := dec.parser.parse()
+	node := dec.parser.parse(true)
 	if node == nil {
 		return io.EOF
 	}
@@ -158,7 +158,7 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	d := newDecoder()
 	p := newParser(in)
 	defer p.destroy()
-	node := p.parse()
+	node := p.parse(true)
 	if node != nil {
 		v := reflect.ValueOf(out)
 		if v.Kind() == reflect.Ptr && !v.IsNil() {
@@ -265,7 +265,7 @@ func (n *Node) Encode(v interface{}) (err error) {
 	p := newParser(e.out)
 	p.textless = true
 	defer p.destroy()
-	doc := p.parse()
+	doc := p.parse(true)
 	*n = *doc.Content[0]
 	return nil
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -25,10 +25,19 @@ func testCycle(c *C, input string, expectedOutput string) {
 	err := yaml.Unmarshal([]byte(input), &node)
 	walkTree(0, &node)
 	c.Assert(err, IsNil)
-	out, err := yaml.Marshal(&node)
-	c.Assert(err, IsNil)
+	var out []byte
+	if node.IsZero() {
+		out = []byte(nil)
+	} else {
+		out, err = yaml.Marshal(&node)
+		c.Assert(err, IsNil)
+	}
 	c.Assert(string(out), DeepEquals, expectedOutput)
-	c.Assert(out, DeepEquals, []byte(expectedOutput))
+	if len(expectedOutput) == 0 {
+		c.Assert(out, DeepEquals, []byte(nil))
+	} else {
+		c.Assert(out, DeepEquals, []byte(expectedOutput))
+	}
 }
 
 
@@ -89,5 +98,16 @@ a:
 
 func (s *S) TestCommentEmptyDoc(c *C) {
 	testIdempotent(c, `# foo
+
+`)
+}
+
+
+func (s *S) TestEmptyDocument(c *C) {
+	testIdempotent(c, ``)
+	testCycle(c, `
+`, ``)
+	testCycle(c, `---
+`, `
 `)
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -47,11 +47,27 @@ d:
 }
 
 
+func (s *S) TestCommentMoving2(c *C) {
+	testIdempotent(c, `a:
+    b:
+        # comment followed by newline
+
+        c: d
+`)
+}
+
+
 func (s *S) TestCommentParsing(c *C) {
 	testIdempotent(c, `# beginning
 a:
     ## foo
     ##
     b:
+`)
+}
+
+
+func (s *S) TestCommentEmptyDoc(c *C) {
+	testIdempotent(c, `# foo
 `)
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -137,18 +137,14 @@ a:
 
 
 func (s *S) TestCommentEmptyDoc(c *C) {
-	testIdempotent(c, `# foo
-`)
+	testIdempotent(c, "# foo\n")
 }
 
 
 func (s *S) TestEmptyDocument(c *C) {
-	testIdempotent(c, ``)
-	testCycle(c, `
-`, ``)
-	testCycle(c, `---
-`, `
-`)
+	testIdempotent(c, "")
+	testCycle(c, "\n", "")
+	testCycle(c, "---\n", "\n")
 }
 
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -63,10 +63,15 @@ d:
 
 
 func (s *S) TestCommentMoving2(c *C) {
-	testIdempotent(c, `a:
+	// The newline is supposed to go away, but the comment should stay above `c: d`
+	testCycle(c, `a:
     b:
         # comment followed by newline
 
+        c: d
+`, `a:
+    b:
+        # comment followed by newline
         c: d
 `)
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -138,7 +138,6 @@ a:
 
 func (s *S) TestCommentEmptyDoc(c *C) {
 	testIdempotent(c, `# foo
-
 `)
 }
 
@@ -161,8 +160,12 @@ func (s *S) TestCommentDocSkip(c *C) {
 key: value
 `)
 	testMDIdempotent(c, `# foo
-
 ---
+key: value
+`)
+	testMDIdempotent(c, `# foo
+---
+# bar
 key: value
 `)
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,14 +1,29 @@
 package yaml_test
 
 import (
+	"fmt"
+	"strings"
+
 	"gopkg.in/yaml.v3"
 	. "gopkg.in/check.v1"
 )
 
 
+func walkTree(indent int, node *yaml.Node) {
+	fmt.Printf("%s{%d %d %#v:%#v anchor:%#v head:%#v line:%#v foot:%#v %d:%d}\n", strings.Repeat("  ", indent), node.Kind, node.Style, node.Tag, node.Value, node.Anchor, node.HeadComment, node.LineComment, node.FootComment, node.Line, node.Column)
+	for _, item := range node.Content {
+		walkTree(indent + 1, item)
+	}
+	if node.Alias != nil {
+		walkTree(indent + 1, node.Alias)
+	}
+}
+
+
 func testCycle(c *C, input string, expectedOutput string) {
 	node := yaml.Node{}
 	err := yaml.Unmarshal([]byte(input), &node)
+	walkTree(0, &node)
 	c.Assert(err, IsNil)
 	out, err := yaml.Marshal(&node)
 	c.Assert(err, IsNil)

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,0 +1,57 @@
+package yaml_test
+
+import (
+	"gopkg.in/yaml.v3"
+	. "gopkg.in/check.v1"
+)
+
+
+func testCycle(c *C, input string, expectedOutput string) {
+	node := yaml.Node{}
+	err := yaml.Unmarshal([]byte(input), &node)
+	c.Assert(err, IsNil)
+	out, err := yaml.Marshal(&node)
+	c.Assert(err, IsNil)
+	c.Assert(string(out), DeepEquals, expectedOutput)
+	c.Assert(out, DeepEquals, []byte(expectedOutput))
+}
+
+
+func testIdempotent(c *C, data string) {
+	testCycle(c, data, data)
+}
+
+
+func (s *S) TestCommentMoving1(c *C) {
+	testIdempotent(c, `# begin
+a:
+    # foo
+    # bar
+    b:
+    # baz
+    c:
+        foo: bar
+        # asdf
+    # bang
+d:
+    # a
+    # b
+    - 1
+    # c
+    - - 123
+      # f
+    # d
+    - 2
+    # e
+`)
+}
+
+
+func (s *S) TestCommentParsing(c *C) {
+	testIdempotent(c, `# beginning
+a:
+    ## foo
+    ##
+    b:
+`)
+}


### PR DESCRIPTION
Fixes two problems with comment handling in `v3` branch found while working on mozilla/sops#791:

1. When unmarshaling and re-marshaling
    ```.yaml
    a:
        b:
            # comment followed by newline

            c: d
    ```
    the comment jumps under `c: d`. (The new line is essential, without it it won't happen.)

2. When unmarshaling and re-marshaling
    ```.yaml
    # foo
    ```
    This parses to a zero node (the comment is lost).

3. When unmarshaling
    ```.yaml
    # foo
    ---
    key: value
    ```
    we end up with only one document containing both the comment and the hash.

The fix for 2 changes the parsing of "empty" documents which contain comments. Instead of returning `nil`, they now return a document node with no content.

I've added some unmarshal + re-marshal tests in `yaml_test.go`.