### PR TITLE
v3: Use map[string] for maps when merged keys are also strings

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -844,7 +844,18 @@ func isStringMap(n *Node) bool {
 	}
 	l := len(n.Content)
 	for i := 0; i < l; i += 2 {
-		if n.Content[i].ShortTag() != strTag {
+		switch n.Content[i].ShortTag() {
+		case strTag:
+			continue
+
+		case mergeTag:
+			alias := n.Content[i+1].Alias
+			if alias == nil || isStringMap(alias) {
+				continue
+			}
+			return false
+
+		default:
 			return false
 		}
 	}


### PR DESCRIPTION
The map type is `map[string]` when all keys in a map are strings. This adds an additional check to ensure that `map[string]` is also the map type used for merges, providing the map to be merged also only contains string keys.

This was reported by @nervo here: https://github.com/go-yaml/yaml/issues/139#issuecomment-566073291

For example:
```
foo:
    &foo
    bar: baz

bar:
    <<: *foo
    baz: qux
```

At the moment returns a `map[interface{}]interface{}`, when ideally, it should be a `map[string]interface{}` because both `bar` and `foo` contain only string keys. This PR fixes this.