### PR TITLE
Update gopkg.in/check.v1 to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
+
+go 1.16
+
+require gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 
 require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+	github.com/kr/pretty v0.3.0 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 )


### PR DESCRIPTION
There has been a few commits to this module in the last year, using a
version from 2020 rather than from 2016 should not hurt, and makes it
look less like a stale dependency.