### PR TITLE
[v3] Fix CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -20,7 +20,7 @@ jobs:
         - "1.13"
         - "1.14"
         - "1.15"
-        - "1.16.0-beta1"
+        - "1.16rc1"
         - "tip"
     env:
       GOPATH: ${{ github.workspace }}/go


### PR DESCRIPTION
CI in https://github.com/go-yaml/yaml/pull/690 currently fails with `Error: Unable to find Go version '1.16.0-beta1' for platform linux and architecture x64.`.