### PR TITLE
Fix indents of the foot comments going after the map

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -296,10 +296,6 @@ func (p *parser) mapping() *Node {
 	}
 	n.LineComment = string(p.event.line_comment)
 	n.FootComment = string(p.event.foot_comment)
-	if n.Style&FlowStyle == 0 && n.FootComment != "" && len(n.Content) > 1 {
-		n.Content[len(n.Content)-2].FootComment = n.FootComment
-		n.FootComment = ""
-	}
 	p.expect(yaml_MAPPING_END_EVENT)
 	return n
 }

--- a/emitterc.go
+++ b/emitterc.go
@@ -241,7 +241,7 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 			emitter.indent += 2
 		} else {
 			// Everything else aligns to the chosen indentation.
-			emitter.indent = emitter.best_indent*((emitter.indent+emitter.best_indent)/emitter.best_indent)
+			emitter.indent = emitter.best_indent * ((emitter.indent + emitter.best_indent) / emitter.best_indent)
 		}
 	}
 	return true
@@ -776,6 +776,10 @@ func yaml_emitter_emit_block_mapping_key(emitter *yaml_emitter_t, event *yaml_ev
 		emitter.indents = emitter.indents[:len(emitter.indents)-1]
 		emitter.state = emitter.states[len(emitter.states)-1]
 		emitter.states = emitter.states[:len(emitter.states)-1]
+
+		if !yaml_emitter_process_foot_comment(emitter) {
+			return false
+		}
 		return true
 	}
 	if !yaml_emitter_write_indent(emitter) {
@@ -813,6 +817,7 @@ func yaml_emitter_emit_block_mapping_value(emitter *yaml_emitter_t, event *yaml_
 			return false
 		}
 	}
+
 	if len(emitter.key_line_comment) > 0 {
 		// [Go] Line comments are generally associated with the value, but when there's
 		//      no value on the same line as a mapping key they end up attached to the

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.16
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/node_test.go
+++ b/node_test.go
@@ -18,12 +18,12 @@ package yaml_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
-	"io"
-	"strings"
 )
 
 var nodeTests = []struct {
@@ -688,17 +688,17 @@ var nodeTests = []struct {
 					Line:        3,
 					Column:      4,
 				}, {
-					Kind:   yaml.ScalarNode,
-					Tag:    "!!str",
-					Value:  "c",
+					Kind:        yaml.ScalarNode,
+					Tag:         "!!str",
+					Value:       "c",
 					LineComment: "# IC",
-					Line:   5,
-					Column: 1,
+					Line:        5,
+					Column:      1,
 				}, {
-					Kind:        yaml.SequenceNode,
-					Tag:         "!!seq",
-					Line:        6,
-					Column:      3,
+					Kind:   yaml.SequenceNode,
+					Tag:    "!!seq",
+					Line:   6,
+					Column: 3,
 					Content: []*yaml.Node{{
 						Kind:   yaml.ScalarNode,
 						Tag:    "!!str",
@@ -707,17 +707,17 @@ var nodeTests = []struct {
 						Column: 5,
 					}},
 				}, {
-					Kind:   yaml.ScalarNode,
-					Tag:    "!!str",
-					Value:  "d",
+					Kind:        yaml.ScalarNode,
+					Tag:         "!!str",
+					Value:       "d",
 					LineComment: "# ID",
-					Line:   7,
-					Column: 1,
+					Line:        7,
+					Column:      1,
 				}, {
-					Kind:        yaml.MappingNode,
-					Tag:         "!!map",
-					Line:        8,
-					Column:      3,
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   8,
+					Column: 3,
 					Content: []*yaml.Node{{
 						Kind:   yaml.ScalarNode,
 						Tag:    "!!str",
@@ -1344,6 +1344,81 @@ var nodeTests = []struct {
 			}},
 		},
 	}, {
+		"m:\n  m:\n    key: value\n  # foot\nn:\n  k: 1\n",
+		yaml.Node{
+			Kind:   yaml.DocumentNode,
+			Line:   1,
+			Column: 1,
+			Content: []*yaml.Node{{
+				Kind:   yaml.MappingNode,
+				Tag:    "!!map",
+				Line:   1,
+				Column: 1,
+				Content: []*yaml.Node{{
+					Kind:   yaml.ScalarNode,
+					Tag:    "!!str",
+					Line:   1,
+					Column: 1,
+					Value:  "m",
+				}, {
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   2,
+					Column: 3,
+					Content: []*yaml.Node{{
+						Kind:        yaml.ScalarNode,
+						Tag:         "!!str",
+						Line:        2,
+						Column:      3,
+						Value:       "m",
+						FootComment: "# foot",
+					}, {
+						Kind:   yaml.MappingNode,
+						Tag:    "!!map",
+						Line:   3,
+						Column: 5,
+						Content: []*yaml.Node{{
+							Kind:   yaml.ScalarNode,
+							Tag:    "!!str",
+							Line:   3,
+							Column: 5,
+							Value:  "key",
+						}, {
+							Kind:   yaml.ScalarNode,
+							Tag:    "!!str",
+							Line:   3,
+							Column: 10,
+							Value:  "value",
+						}},
+					}},
+				}, {
+					Kind:   yaml.ScalarNode,
+					Tag:    "!!str",
+					Line:   5,
+					Column: 1,
+					Value:  "n",
+				}, {
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   6,
+					Column: 3,
+					Content: []*yaml.Node{{
+						Kind:   yaml.ScalarNode,
+						Tag:    "!!str",
+						Line:   6,
+						Column: 3,
+						Value:  "k",
+					}, {
+						Kind:   yaml.ScalarNode,
+						Tag:    "!!int",
+						Line:   6,
+						Column: 6,
+						Value:  "1",
+					}},
+				}},
+			}},
+		},
+	}, {
 		"# DH1\n\n# HA1\nka:\n  # HB1\n  kb:\n    # HC1\n    # HC2\n    - lc # IC\n    # FC1\n    # FC2\n\n    # HD1\n    - ld # ID\n    # FD1\n\n# DF1\n",
 		yaml.Node{
 			Kind:        yaml.DocumentNode,
@@ -1576,16 +1651,16 @@ var nodeTests = []struct {
 			Line:        7,
 			Column:      1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   7,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        7,
+				Column:      1,
+				FootComment: "# FA1\n# FA2",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1\n# HA2",
-					FootComment: "# FA1\n# FA2",
 					Line:        7,
 					Column:      1,
 				}, {
@@ -1661,16 +1736,16 @@ var nodeTests = []struct {
 			Line:   2,
 			Column: 1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   2,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        2,
+				Column:      1,
+				FootComment: "# FA1",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1",
-					FootComment: "# FA1",
 					Line:        2,
 					Column:      1,
 				}, {
@@ -1704,16 +1779,16 @@ var nodeTests = []struct {
 			Line:   2,
 			Column: 1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   2,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        2,
+				Column:      1,
+				FootComment: "# FA1",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1",
-					FootComment: "# FA1",
 					Line:        2,
 					Column:      1,
 				}, {
@@ -1747,16 +1822,16 @@ var nodeTests = []struct {
 			Line:   2,
 			Column: 1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   2,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        2,
+				Column:      1,
+				FootComment: "# FA1",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1",
-					FootComment: "# FA1",
 					Line:        2,
 					Column:      1,
 				}, {
@@ -1789,16 +1864,16 @@ var nodeTests = []struct {
 			Line:   2,
 			Column: 1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   2,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        2,
+				Column:      1,
+				FootComment: "# FA1",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1",
-					FootComment: "# FA1",
 					Line:        2,
 					Column:      1,
 				}, {
@@ -1832,16 +1907,16 @@ var nodeTests = []struct {
 			Line:   2,
 			Column: 1,
 			Content: []*yaml.Node{{
-				Kind:   yaml.MappingNode,
-				Tag:    "!!map",
-				Line:   2,
-				Column: 1,
+				Kind:        yaml.MappingNode,
+				Tag:         "!!map",
+				Line:        2,
+				Column:      1,
+				FootComment: "# FA1",
 				Content: []*yaml.Node{{
 					Kind:        yaml.ScalarNode,
 					Tag:         "!!str",
 					Value:       "ka",
 					HeadComment: "# HA1",
-					FootComment: "# FA1",
 					Line:        2,
 					Column:      1,
 				}, {

--- a/yamlh.go
+++ b/yamlh.go
@@ -602,8 +602,9 @@ type yaml_parser_t struct {
 	tail_comment []byte // Foot comment that happens at the end of a block.
 	stem_comment []byte // Comment in item preceding a nested structure (list inside list item, etc)
 
-	comments      []yaml_comment_t // The folded comments for all parsed tokens
-	comments_head int
+	comments            []yaml_comment_t // The folded comments for all parsed tokens
+	comments_head       int
+	next_block_comments []yaml_comment_t // The stack of comments that should be unwinded when the next MAPPING_END comes
 
 	// Scanner stuff
 
@@ -639,7 +640,6 @@ type yaml_parser_t struct {
 }
 
 type yaml_comment_t struct {
-
 	scan_mark  yaml_mark_t // Position where scanning for comments started
 	token_mark yaml_mark_t // Position after which tokens will be associated with this comment
 	start_mark yaml_mark_t // Position of '#' comment mark


### PR DESCRIPTION
Removed the function that was adding the comments to the last key from
the map and replaced that with the separate comments queue.

Unfold that comment queue each time we get the end of a flow, a document and
a block.
Append comments to the end token if their indents are >= than the first
comment indent (this is safe as we only add comments to that queue if we
detect that their indent is < than the last key indent).

Additionally fixed the bug in the emitter, related to skipping
foot_comments for the mapping end events.

Fixes: https://github.com/go-yaml/yaml/issues/709

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>