### PR TITLE
Introduce RawYAML interface that can allow passing raw yaml blocks

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -316,6 +316,16 @@ func yaml_alias_event_initialize(event *yaml_event_t, anchor []byte) bool {
 	*event = yaml_event_t{
 		typ:    yaml_ALIAS_EVENT,
 		anchor: anchor,
+	}
+	return true
+}
+
+// Create RAW.
+func yaml_raw_event_initialize(event *yaml_event_t, value []byte) bool {
+	*event = yaml_event_t{
+		typ:      yaml_RAW_EVENT,
+		value:    value,
+		implicit: true,
 	}
 	return true
 }

--- a/encode.go
+++ b/encode.go
@@ -136,6 +136,14 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 	case time.Duration:
 		e.stringv(tag, reflect.ValueOf(value.String()))
 		return
+	case RawYAML:
+		v, err := value.MarshalYAMLBytes()
+		if err != nil {
+			fail(err)
+		}
+
+		e.emitRaw(v, "", tag)
+		return
 	case Marshaler:
 		v, err := value.MarshalYAML()
 		if err != nil {
@@ -409,6 +417,11 @@ func (e *encoder) floatv(tag string, in reflect.Value) {
 
 func (e *encoder) nilv() {
 	e.emitScalar("null", "", "", yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
+}
+
+func (e *encoder) emitRaw(value []byte, anchor, tag string) {
+	e.must(yaml_raw_event_initialize(&e.event, value))
+	e.emit()
 }
 
 func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_t, head, line, foot, tail []byte) {

--- a/yaml.go
+++ b/yaml.go
@@ -51,6 +51,12 @@ type Marshaler interface {
 	MarshalYAML() (interface{}, error)
 }
 
+// The RawYAML interface may be implemented by types that output raw YAML data
+// which is then written as is using proper indents.
+type RawYAML interface {
+	MarshalYAMLBytes() ([]byte, error)
+}
+
 // Unmarshal decodes the first document found within the in byte slice
 // and assigns decoded values into the out value.
 //
@@ -363,7 +369,7 @@ const (
 //             Address yaml.Node
 //     }
 //     err := yaml.Unmarshal(data, &person)
-// 
+//
 // Or by itself:
 //
 //     var person Node
@@ -373,7 +379,7 @@ type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -420,7 +426,6 @@ func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
-
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed

--- a/yamlh.go
+++ b/yamlh.go
@@ -53,6 +53,20 @@ const (
 
 type yaml_break_t int
 
+func (b yaml_break_t) bytes() []byte {
+	switch b {
+	case yaml_CR_BREAK:
+		return []byte("\r")
+	case yaml_LN_BREAK:
+		return []byte("\n")
+	case yaml_CRLN_BREAK:
+		return []byte("\r\n")
+	default:
+		panic("unknown line break setting")
+	}
+
+}
+
 // Line break types.
 const (
 	// Let the parser choose the break type.
@@ -261,6 +275,7 @@ const (
 	yaml_MAPPING_START_EVENT  // A MAPPING-START event.
 	yaml_MAPPING_END_EVENT    // A MAPPING-END event.
 	yaml_TAIL_COMMENT_EVENT
+	yaml_RAW_EVENT
 )
 
 var eventStrings = []string{
@@ -276,6 +291,7 @@ var eventStrings = []string{
 	yaml_MAPPING_START_EVENT:  "mapping start",
 	yaml_MAPPING_END_EVENT:    "mapping end",
 	yaml_TAIL_COMMENT_EVENT:   "tail comment",
+	yaml_RAW_EVENT:            "raw block",
 }
 
 func (e yaml_event_type_t) String() string {
@@ -639,7 +655,6 @@ type yaml_parser_t struct {
 }
 
 type yaml_comment_t struct {
-
 	scan_mark  yaml_mark_t // Position where scanning for comments started
 	token_mark yaml_mark_t // Position after which tokens will be associated with this comment
 	start_mark yaml_mark_t // Position of '#' comment mark


### PR DESCRIPTION
Then these block will be inlined as valid YAML istead of using quoted or
escaped format which is used for strings.
This can be used if you already have a decoded yaml which you want to inline into another object, when decoding/encoding that yaml is not really option.
That is helpful to get a workaround for comments decoding issues like https://github.com/go-yaml/yaml/issues/709

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>