### PR TITLE
Fix key-sorting bugs.

### DIFF
--- a/sorter.go
+++ b/sorter.go
@@ -2,7 +2,6 @@ package yaml
 
 import (
 	"reflect"
-	"strings"
 	"unicode"
 )
 
@@ -63,12 +62,12 @@ func (l keyList) Less(i, j int) bool {
 				// shorter numbers are always smaller
 				return cmp < 0
 			}
-			if cmp := strings.Compare(string(ar[i+azeroes:i+adigits]), string(br[i+bzeroes:i+bdigits])); cmp != 0 {
+			if as, bs := string(ar[i+azeroes:i+adigits]), string(br[i+bzeroes:i+bdigits]); as != bs {
 				// with leading zeroes removed,
 				// equal-length numbers sort in the
 				// same order as their string
 				// representation
-				return cmp < 0
+				return as < bs
 			}
 			if cmp := azeroes - bzeroes; cmp != 0 {
 				return cmp < 0


### PR DESCRIPTION
Existing key sorting is nondeterministic because (keyList)Less() returns contradictory results.
* Less("7a","8a") returns true: 7 < 8
* Less("8a","77") returns true: 8 < 77
* Less("77","7a") returns true: the first char is equal ("continue"), then "7" < "a" because "a" is a letter

(This has been [reported previously on a closed issue](https://github.com/go-yaml/yaml/pull/195#issuecomment-440818560).)

There are other surprising behaviors, too:
* Numbers that overflow int64 are sorted strangely ("9223372036854775808" < "9223372036854775807")
* Non-ASCII digits are sorted strangely ("\u0666" is sorted as if it's "1590")

This commit fixes the above issues, adds some keys in the sorting test to expose some edge cases, and adds a loop in the test to more reliably catch nondeterministic sorting.