### PR TITLE
Fix instability in key ordering.

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -614,6 +614,9 @@ func (s *S) TestSortedOutput(c *C) {
 		"d7abc",
 		"d12",
 		"d12a",
+		"e2b",
+		"e4b",
+		"e21a",
 	}
 	m := make(map[interface{}]int)
 	for _, k := range order {

--- a/sorter.go
+++ b/sorter.go
@@ -37,8 +37,10 @@ func (l keyList) Less(i, j int) bool {
 		return ak < bk
 	}
 	ar, br := []rune(a.String()), []rune(b.String())
+	digits := false
 	for i := 0; i < len(ar) && i < len(br); i++ {
 		if ar[i] == br[i] {
+			digits = unicode.IsDigit(ar[i])
 			continue
 		}
 		al := unicode.IsLetter(ar[i])
@@ -47,7 +49,11 @@ func (l keyList) Less(i, j int) bool {
 			return ar[i] < br[i]
 		}
 		if al || bl {
-			return bl
+			if digits {
+				return al
+			} else {
+				return bl
+			}
 		}
 		var ai, bi int
 		var an, bn int64


### PR DESCRIPTION
In  https://github.com/go-yaml/yaml/issues/444#issuecomment-481268195

@niemeyer says:

> I've fixed it in cdc409d in v3. I'll backport it to v2 later.

The cherry-pick applies cleanly. I tested it against my program that narrowed down my issue which led me to find #444 in the first place: https://github.com/mkmik/yamlsortbug

