### PR TITLE
v3: Tests on multi os

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -4,10 +4,13 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
+        os:
+        - "ubuntu-20.04"
+        - "macos-10.15"
+        - "windows-2019"
         go:
         - "1.5"
         - "1.6"
@@ -20,8 +23,15 @@ jobs:
         - "1.13"
         - "1.14"
         - "1.15"
-        - "1.16.0-beta1"
+        - "1.16"
+        - "1.17.0-beta1"
         - "tip"
+        exclude:
+        - os: "macos-10.15"
+          go: "tip"
+        - os: "windows-2019"
+          go: "tip"
+    runs-on: ${{ matrix.os }}
     env:
       GOPATH: ${{ github.workspace }}/go
     steps:


### PR DESCRIPTION
- Run tests on linux/macos/windows
- Switch from go version 1.16 beta to 1.16 stable
- Add go version 1.17 beta

What motivated my pull request was seeing some strange behaviors on windows platform. Before further investigations and eventuelly a fixing pull request, i think it's good to have a solid and multi os continuous integration :)

Note: as you probably can see, tests are broken for obscure reasons on `macos-10.15` versions `1.5` and `1.6`. It *could* be time for removing go old versions support OR to add more github action exclusions :)