### PR TITLE
Allow to get source position of unmarshal error

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1111,8 +1111,8 @@ func (s *S) TestUnmarshalerWholeDocument(c *C) {
 }
 
 func (s *S) TestUnmarshalerTypeError(c *C) {
-	unmarshalerResult[2] = &yaml.TypeError{[]string{"foo"}}
-	unmarshalerResult[4] = &yaml.TypeError{[]string{"bar"}}
+	unmarshalerResult[2] = &yaml.TypeError{[]yaml.UnmarshalError{{"foo", 1, 1}}}
+	unmarshalerResult[4] = &yaml.TypeError{[]yaml.UnmarshalError{{"bar", 1, 1}}}
 	defer func() {
 		delete(unmarshalerResult, 2)
 		delete(unmarshalerResult, 4)
@@ -1129,8 +1129,8 @@ func (s *S) TestUnmarshalerTypeError(c *C) {
 	c.Assert(err, ErrorMatches, ""+
 		"yaml: unmarshal errors:\n"+
 		"  line 1: cannot unmarshal !!str `A` into int\n"+
-		"  foo\n"+
-		"  bar\n"+
+		"  line 1: foo\n"+
+		"  line 1: bar\n"+
 		"  line 1: cannot unmarshal !!str `B` into int")
 	c.Assert(v.M["abc"], NotNil)
 	c.Assert(v.M["def"], IsNil)
@@ -1142,8 +1142,8 @@ func (s *S) TestUnmarshalerTypeError(c *C) {
 }
 
 func (s *S) TestObsoleteUnmarshalerTypeError(c *C) {
-	unmarshalerResult[2] = &yaml.TypeError{[]string{"foo"}}
-	unmarshalerResult[4] = &yaml.TypeError{[]string{"bar"}}
+	unmarshalerResult[2] = &yaml.TypeError{[]yaml.UnmarshalError{{"foo", 1, 1}}}
+	unmarshalerResult[4] = &yaml.TypeError{[]yaml.UnmarshalError{{"bar", 1, 1}}}
 	defer func() {
 		delete(unmarshalerResult, 2)
 		delete(unmarshalerResult, 4)
@@ -1160,8 +1160,8 @@ func (s *S) TestObsoleteUnmarshalerTypeError(c *C) {
 	c.Assert(err, ErrorMatches, ""+
 		"yaml: unmarshal errors:\n"+
 		"  line 1: cannot unmarshal !!str `A` into int\n"+
-		"  foo\n"+
-		"  bar\n"+
+		"  line 1: foo\n"+
+		"  line 1: bar\n"+
 		"  line 1: cannot unmarshal !!str `B` into int")
 	c.Assert(v.M["abc"], NotNil)
 	c.Assert(v.M["def"], IsNil)

--- a/yaml.go
+++ b/yaml.go
@@ -308,16 +308,27 @@ func failf(format string, args ...interface{}) {
 	panic(yamlError{fmt.Errorf("yaml: "+format, args...)})
 }
 
+// UnmarshalError is each error with a source position found by Unmarshal.
+type UnmarshalError struct {
+	Message string
+	Line    int
+	Column  int
+}
+
 // A TypeError is returned by Unmarshal when one or more fields in
 // the YAML document cannot be properly decoded into the requested
 // types. When this error is returned, the value is still
 // unmarshaled partially.
 type TypeError struct {
-	Errors []string
+	Errors []UnmarshalError
 }
 
 func (e *TypeError) Error() string {
-	return fmt.Sprintf("yaml: unmarshal errors:\n  %s", strings.Join(e.Errors, "\n  "))
+	msgs := make([]string, 0, len(e.Errors))
+	for _, err := range e.Errors {
+		msgs = append(msgs, fmt.Sprintf("line %d: %s", err.Line, err.Message))
+	}
+	return fmt.Sprintf("yaml: unmarshal errors:\n  %s", strings.Join(msgs, "\n  "))
 }
 
 type Kind uint32

--- a/yaml.go
+++ b/yaml.go
@@ -324,11 +324,12 @@ type TypeError struct {
 }
 
 func (e *TypeError) Error() string {
-	msgs := make([]string, 0, len(e.Errors))
+	var b strings.Builder
+	b.WriteString("yaml: unmarshal errors:")
 	for _, err := range e.Errors {
-		msgs = append(msgs, fmt.Sprintf("line %d: %s", err.Line, err.Message))
+		b.WriteString(fmt.Sprintf("\n  line %d: %s", err.Line, err.Message))
 	}
-	return fmt.Sprintf("yaml: unmarshal errors:\n  %s", strings.Join(msgs, "\n  "))
+	return b.String()
 }
 
 type Kind uint32


### PR DESCRIPTION
Fixes #759

With this PR, error instances in `TypeError.Errors` know their source positions. Previously the field was string slice, but now it is slice of struct of message, line and column so that the caller can know where each error occurred exactly.