### PR TITLE
yaml: make struct info tag configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module github.com/programmfabrik/yaml
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.16
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/yaml.go
+++ b/yaml.go
@@ -545,7 +545,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 
 		info := fieldInfo{Num: i}
 
-		tag := field.Tag.Get("yaml")
+		tag := field.Tag.Get(YAML_STRUCT_TAG)
 		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
 			tag = string(field.Tag)
 		}

--- a/yamlh.go
+++ b/yamlh.go
@@ -27,6 +27,9 @@ import (
 	"io"
 )
 
+// Tag used in struct info
+var YAML_STRUCT_TAG string = "yaml"
+
 // The version directive data.
 type yaml_version_directive_t struct {
 	major int8 // The major version number.


### PR DESCRIPTION
In order to parse Kubernetes resources, we need to use the json struct info tags provided by Kubernetes.