### PR TITLE
feat: add inline struct ptr support

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -501,6 +501,15 @@ var unmarshalTests = []struct {
 		}{1, inlineB{2, inlineC{3}}},
 	},
 
+	// Struct inlining with ptr
+	{
+		"a: 1\nc: 3\n",
+		&struct {
+			A        int
+			*InlineC `yaml:",inline"`
+		}{1, &InlineC{3}},
+	},
+
 	// Map inlining
 	{
 		"a: 1\nb: 2\nc: 3\n",
@@ -697,7 +706,7 @@ var unmarshalTests = []struct {
 		M{"a": 123456e1},
 	}, {
 		"a: 123456E1\n",
-		M{"a": 123456E1},
+		M{"a": 123456e1},
 	},
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{
@@ -744,6 +753,10 @@ type inlineB struct {
 }
 
 type inlineC struct {
+	C int
+}
+
+type InlineC struct {
 	C int
 }
 
@@ -870,14 +883,14 @@ var unmarshalErrorTests = []struct {
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
-		"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
-		"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
-		"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
-		"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
-		"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
-		"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
-		"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
-		"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
+			"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
+			"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
+			"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
+			"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
+			"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
+			"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
+			"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
+			"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
 		"yaml: document contains excessive aliasing",
 	},
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -406,8 +406,8 @@ func (s *S) TestLineWrapping(c *C) {
 	data, err := yaml.Marshal(v)
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals,
-		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz\n" +
-		"  ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n")
+		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz\n"+
+			"  ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n")
 
 	// The API does not allow this process to be reversed as it's intended
 	// for migration only. v3 drops this method and instead offers more
@@ -477,7 +477,7 @@ var marshalErrorTests = []struct {
 		B       int
 		inlineB ",inline"
 	}{1, inlineB{2, inlineC{3}}},
-	panic: `Duplicated key 'b' in struct struct \{ B int; .*`,
+	panic: `Duplicated key "b" in struct "struct \{ B int; .*`,
 }, {
 	value: &struct {
 		A int

--- a/encode_test.go
+++ b/encode_test.go
@@ -293,6 +293,21 @@ var marshalTests = []struct {
 		"a: 1\nb: 2\nc: 3\n",
 	},
 
+	{
+		&struct {
+			A        int
+			*InlineC `yaml:",inline"`
+		}{1, &InlineC{3}},
+		"a: 1\nc: 3\n",
+	},
+	{
+		&struct {
+			A        int
+			*InlineC `yaml:",inline"`
+		}{1, nil},
+		"a: 1\n",
+	},
+
 	// Map inlining
 	{
 		&struct {

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Add support for inline struct pointers for exported fields.

Also:
* Cleanup errors using fmt.Errorf instead of string concatenating.
* Removed commented out code.
* Formatted edited files with goimports.

Fixes #55