### PR TITLE
fix: inline map set to nil

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -733,7 +733,6 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 	var elemType reflect.Type
 	if sinfo.InlineMap != -1 {
 		inlineMap = out.Field(sinfo.InlineMap)
-		inlineMap.Set(reflect.New(inlineMap.Type()).Elem())
 		elemType = inlineMap.Type().Elem()
 	}
 


### PR DESCRIPTION
Fix line maps being set to nil if no elements are found after calling yaml.Unmarshal.

Fixes #793