### PR TITLE
Cherrypick to v2: Use context line for reporting

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -111,14 +111,18 @@ func (p *parser) peek() yaml_event_type_t {
 func (p *parser) fail() {
 	var where string
 	var line int
-	if p.parser.problem_mark.line != 0 {
+	if p.parser.context_mark.line != 0 {
+		line = p.parser.context_mark.line
+		// Scanner errors don't iterate line before returning error
+		if p.parser.error == yaml_SCANNER_ERROR {
+			line++
+		}
+	} else if p.parser.problem_mark.line != 0 {
 		line = p.parser.problem_mark.line
 		// Scanner errors don't iterate line before returning error
 		if p.parser.error == yaml_SCANNER_ERROR {
 			line++
 		}
-	} else if p.parser.context_mark.line != 0 {
-		line = p.parser.context_mark.line
 	}
 	if line != 0 {
 		where = "line " + strconv.Itoa(line) + ": "

--- a/decode_test.go
+++ b/decode_test.go
@@ -868,6 +868,7 @@ var unmarshalErrorTests = []struct {
 	{"b: *a\na: &a {c: 1}", `yaml: unknown anchor 'a' referenced`},
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
+	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
 		"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +


### PR DESCRIPTION
kubernetes-sigs/yaml uses v2 of go-yaml, and this fix is necessary for correctly identifying where errors are in large yaml files, so it would be great to have this added to v2.

For example, I'd like to have this for debugging charts in helm: https://github.com/helm/helm/pull/8699