### PR TITLE
v3: Enabled shallow merge when unmarshal to struct.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -315,11 +315,12 @@ type decoder struct {
 	stringMapType  reflect.Type
 	generalMapType reflect.Type
 
-	knownFields bool
-	uniqueKeys  bool
-	decodeCount int
-	aliasCount  int
-	aliasDepth  int
+	knownFields  bool
+	uniqueKeys   bool
+	shallowMerge bool
+	decodeCount  int
+	aliasCount   int
+	aliasDepth   int
 }
 
 var (
@@ -337,6 +338,7 @@ func newDecoder() *decoder {
 		stringMapType:  stringMapType,
 		generalMapType: generalMapType,
 		uniqueKeys:     true,
+		shallowMerge:   false,
 	}
 	d.aliases = make(map[*Node]bool)
 	return d
@@ -898,6 +900,12 @@ func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 				field = out.Field(info.Num)
 			} else {
 				field = d.fieldByIndex(n, out, info.Inline)
+			}
+			if d.shallowMerge {
+				empty := reflect.Zero(field.Type())
+				if field != empty {
+					field.Set(empty)
+				}
 			}
 			d.unmarshal(n.Content[i+1], field)
 		} else if sinfo.InlineMap != -1 {

--- a/decode_test.go
+++ b/decode_test.go
@@ -767,7 +767,7 @@ var unmarshalTests = []struct {
 		M{"a": 123456e1},
 	}, {
 		"a: 123456E1\n",
-		M{"a": 123456E1},
+		M{"a": 123456e1},
 	},
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{
@@ -802,7 +802,6 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
-
 }
 
 type M map[string]interface{}
@@ -950,14 +949,14 @@ var unmarshalErrorTests = []struct {
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
-		"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
-		"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
-		"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
-		"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
-		"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
-		"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
-		"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
-		"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
+			"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
+			"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
+			"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
+			"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
+			"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
+			"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
+			"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
+			"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
 		"yaml: document contains excessive aliasing",
 	},
 }
@@ -1436,7 +1435,47 @@ func (s *S) TestMergeStruct(c *C) {
 	}
 }
 
-var unmarshalNullTests = []struct{ input string; pristine, expected func() interface{} }{{
+var shallowMergeStructDecoderTest = `
+config: &config
+  key1: 1
+  map1:
+    mapkey1: 1
+    mapkey2: 2
+otherconfig:
+  <<: *config
+  map1:
+    mapkey1: 3
+`
+
+func (s *S) TestShallowMergeStructDecoder(c *C) {
+	type Map1 struct {
+		Mapkey1 int `yaml:"mapkey1"`
+		Mapkey2 int `yaml:"mapkey2"`
+	}
+
+	type Config struct {
+		Key1 int  `yaml:"key1"`
+		Map1 Map1 `yaml:"map1"`
+	}
+
+	type Top struct {
+		Config      Config `yaml:"config"`
+		Otherconfig Config `yaml:"otherconfig"`
+	}
+
+	var m Top
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(shallowMergeStructDecoderTest)))
+	dec.ShallowMerge(true)
+	err := dec.Decode(&m)
+	c.Assert(err, IsNil)
+	want := Top{Config{1, Map1{1, 2}}, Config{1, Map1{3, 0}}}
+	c.Assert(m, Equals, want, Commentf("test %q failed", "TestShallowMergeStructDecoder: line 1453"))
+}
+
+var unmarshalNullTests = []struct {
+	input              string
+	pristine, expected func() interface{}
+}{{
 	"null",
 	func() interface{} { var v interface{}; v = "v"; return &v },
 	func() interface{} { var v interface{}; v = nil; return &v },
@@ -1487,7 +1526,7 @@ func (s *S) TestUnmarshalNull(c *C) {
 func (s *S) TestUnmarshalPreservesData(c *C) {
 	var v struct {
 		A, B int
-		C int `yaml:"-"`
+		C    int `yaml:"-"`
 	}
 	v.A = 42
 	v.C = 88

--- a/yaml.go
+++ b/yaml.go
@@ -91,8 +91,9 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 
 // A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	parser      *parser
-	knownFields bool
+	parser       *parser
+	knownFields  bool
+	shallowMerge bool
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -111,6 +112,13 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
+// ShallowMerge ensures that the merge is shallow when
+// unmarshalling to a struct, as opposed
+// to the default merge behavior, which is deep.
+func (dec *Decoder) ShallowMerge(enable bool) {
+	dec.shallowMerge = enable
+}
+
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v.
 //
@@ -119,6 +127,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
+	d.shallowMerge = dec.shallowMerge
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -363,7 +372,7 @@ const (
 //             Address yaml.Node
 //     }
 //     err := yaml.Unmarshal(data, &person)
-// 
+//
 // Or by itself:
 //
 //     var person Node
@@ -373,7 +382,7 @@ type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -420,7 +429,6 @@ func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
-
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed


### PR DESCRIPTION
This creates a flag called "shallowMerge" in the decoder to force the merge to be shallow when unmarshalling from yaml to struct. It will fix issue #818 @niemeyer 