### PR TITLE
Replace initialization code for decode ifaceType

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -323,11 +323,12 @@ type decoder struct {
 }
 
 var (
+	sliceOfEmptyInterface []interface{}
 	nodeType       = reflect.TypeOf(Node{})
 	durationType   = reflect.TypeOf(time.Duration(0))
 	stringMapType  = reflect.TypeOf(map[string]interface{}{})
 	generalMapType = reflect.TypeOf(map[interface{}]interface{}{})
-	ifaceType      = generalMapType.Elem()
+	ifaceType      = reflect.TypeOf(sliceOfEmptyInterface).Elem()
 	timeType       = reflect.TypeOf(time.Time{})
 	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )


### PR DESCRIPTION
Tinygo currently does not support reflect.Elem() on a map value.
In order to be able to compile programs that use yaml.v3 with tinygo
(for example to compile to wasm), we should replace the variable
initialization of ifaceType with something that tinygo understands.

The tinygo reflect `Type.Elem()` currently does not support the `map` type: https://github.com/tinygo-org/tinygo/blob/3883550c446fc8b14115366284316290f3d3c4b1/src/reflect/type.go#L348-L365
And also the interpreter of tinygo does not have support for it: https://github.com/tinygo-org/tinygo/blob/3883550c446fc8b14115366284316290f3d3c4b1/interp/interpreter.go#L363-L370

But there are two PRs open with major refactorings for both of these systems, so maybe in the future it will have support for it:
* https://github.com/tinygo-org/tinygo/pull/2640
* https://github.com/tinygo-org/tinygo/pull/2655