### PR TITLE
v3: fix isStringMap detection with merge

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -844,7 +844,37 @@ func isStringMap(n *Node) bool {
 	}
 	l := len(n.Content)
 	for i := 0; i < l; i += 2 {
-		if n.Content[i].ShortTag() != strTag {
+		if isMerge(n.Content[i]) {
+			nn := n.Content[i+1]
+			switch nn.Kind {
+			case MappingNode:
+				if !isStringMap(nn) {
+					return false
+				}
+			case AliasNode:
+				if nn.Alias != nil && !isStringMap(nn.Alias) {
+					return false
+				}
+			case SequenceNode:
+				l := len(nn.Content)
+				for i := 0; i < l; i++ {
+					switch nn.Content[i].Kind {
+					case AliasNode:
+						if nn.Content[i].Alias != nil && !isStringMap(nn.Content[i].Alias) {
+							return false
+						}
+					case MappingNode:
+						if !isStringMap(nn.Content[i]) {
+							return false
+						}
+					default:
+						return false
+					}
+				}
+			default:
+				return false
+			}
+		} else if n.Content[i].ShortTag() != strTag {
 			return false
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1391,7 +1391,7 @@ inlineSequenceMap:
 `
 
 func (s *S) TestMerge(c *C) {
-	var want = map[interface{}]interface{}{
+	var want = map[string]interface{}{
 		"x":     1,
 		"y":     2,
 		"r":     10,


### PR DESCRIPTION
This fixes the implicit map types when using merge, now isStringMap
will look at the merged in structure instead of immediately returning
false for `!!merge` tags.

This is similar to #693 but covers a few more edge cases.