### PR TITLE
v3: Add nil encoding options.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -29,16 +29,17 @@ import (
 )
 
 type encoder struct {
-	emitter  yaml_emitter_t
-	event    yaml_event_t
-	out      []byte
-	flow     bool
-	indent   int
-	doneInit bool
+	emitter     yaml_emitter_t
+	event       yaml_event_t
+	out         []byte
+	flow        bool
+	indent      int
+	nilEncoding NilEncoding
+	doneInit    bool
 }
 
 func newEncoder() *encoder {
-	e := &encoder{}
+	e := &encoder{nilEncoding: LowerCaseNullNilEncoding}
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -46,7 +47,7 @@ func newEncoder() *encoder {
 }
 
 func newEncoderWithWriter(w io.Writer) *encoder {
-	e := &encoder{}
+	e := &encoder{nilEncoding: LowerCaseNullNilEncoding}
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_writer(&e.emitter, w)
 	yaml_emitter_set_unicode(&e.emitter, true)
@@ -408,7 +409,7 @@ func (e *encoder) floatv(tag string, in reflect.Value) {
 }
 
 func (e *encoder) nilv() {
-	e.emitScalar("null", "", "", yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
+	e.emitScalar(e.nilEncoding.String(), "", "", yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
 }
 
 func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_t, head, line, foot, tail []byte) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -622,7 +622,7 @@ func (s *S) TestMarshaler(c *C) {
 		obj.Field.value = item.value
 		data, err := yaml.Marshal(obj)
 		c.Assert(err, IsNil)
-		c.Assert(string(data), Equals, string(item.data))
+		c.Assert(string(data), Equals, item.data)
 	}
 }
 
@@ -654,6 +654,45 @@ func (s *S) TestSetIndent(c *C) {
 	err = enc.Close()
 	c.Assert(err, Equals, nil)
 	c.Assert(buf.String(), Equals, "a:\n        b:\n                c: d\n")
+}
+
+func (s *S) TestSetNilEncoding(c *C) {
+	input := map[string]interface{}{"a": nil}
+	tests := []struct {
+		want     string
+		encoding yaml.NilEncoding
+	}{
+		{
+			encoding: yaml.LowerCaseNullNilEncoding,
+			want:     "a: null\n",
+		},
+		{
+			encoding: yaml.UpperCaseNullNilEncoding,
+			want:     "a: NULL\n",
+		},
+		{
+			encoding: yaml.PascalCaseNullNilEncoding,
+			want:     "a: Null\n",
+		},
+		{
+			encoding: yaml.TildeNilEncoding,
+			want:     "a: ~\n",
+		},
+		{
+			encoding: yaml.EmptyNilEncoding,
+			want:     "a:\n",
+		},
+	}
+	for _, test := range tests {
+		var buf bytes.Buffer
+		enc := yaml.NewEncoder(&buf)
+		enc.SetNilEncoding(test.encoding)
+		err := enc.Encode(input)
+		c.Assert(err, Equals, nil)
+		err = enc.Close()
+		c.Assert(err, Equals, nil)
+		c.Assert(buf.String(), Equals, test.want)
+	}
 }
 
 func (s *S) TestSortedOutput(c *C) {


### PR DESCRIPTION
Implementation of https://github.com/go-yaml/yaml/issues/839. Adds a `NilEncoding` enum that can be set on the `Encoder`. This is then used in `nilv` to set the string. Defaults the encoding to `LowerCaseNullNilEncoding` to maintain expected default behavior.