### PR TITLE
fix: re-add option to switch off unique mapping keys enforcement

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1481,7 +1481,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1497,7 +1497,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1515,10 +1515,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,
@@ -1614,10 +1614,11 @@ var unmarshalStrictTests = []struct {
 	value  interface{}
 	error  string
 }{{
-	known: true,
-	data:  "a: 1\nc: 2\n",
-	value: struct{ A, B int }{A: 1},
-	error: `yaml: unmarshal errors:\n  line 2: field c not found in type struct { A int; B int }`,
+	known:  true,
+	unique: false,
+	data:   "a: 1\nc: 2\n",
+	value:  struct{ A, B int }{A: 1},
+	error:  `yaml: unmarshal errors:\n  line 2: field c not found in type struct { A int; B int }`,
 }, {
 	unique: true,
 	data:   "a: 1\nb: 2\na: 3\n",
@@ -1697,6 +1698,7 @@ func (s *S) TestUnmarshalKnownFields(c *C) {
 		value := reflect.New(t)
 		dec := yaml.NewDecoder(bytes.NewBuffer([]byte(item.data)))
 		dec.KnownFields(item.known)
+		dec.UniqueKeys(item.unique)
 		err := dec.Decode(value.Interface())
 		c.Assert(err, ErrorMatches, item.error)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.17
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR partially reverts https://github.com/go-yaml/yaml/commit/309c9d15755818936fcb0f5c171692693a47efe2 while keeping unique mapping keys enforcement as default behaviour for `Unmarshal`.

The rationale is that libraries like `ghodss/yaml` relies on `uniqueKeys` being set to `false`. Giving the possibility to do so would allow the upgrade of `go-yaml` to `v3` without introducing breaking changes.