### PR TITLE
fix: Support escaped slash in strings

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -802,6 +802,15 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
+
+	// Issue #797 - escaped slash
+	{
+		"a: \"\\/\"\nb: /",
+		map[string]interface{}{
+			"a": "/",
+			"b": "/",
+		},
+	},
 }
 
 type M map[string]interface{}

--- a/scannerc.go
+++ b/scannerc.go
@@ -2543,6 +2543,10 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 					code_length = 4
 				case 'U':
 					code_length = 8
+				case '/':
+					// Support escaped slash ("\/"), as required by YAML 1.2.0+
+					// for strict JSON compatibility
+					s = append(s, '/')
 				default:
 					yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
 						start_mark, "found unknown escape character")


### PR DESCRIPTION
Fixes #797

The JSON spec lists the `/` character as optionally-escapable, and so YAML v1.2.0 added support for the sequence `\/` to be unescaped to `/`.

This PR adds the minimum necessary support for this, and should solve the issues that a few people have already hit, as documented in #797.

Thanks!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>