### PR TITLE
fix: scalar indent indicator [#643]

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -159,14 +159,6 @@ func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t
 // Set the canonical output style.
 func yaml_emitter_set_canonical(emitter *yaml_emitter_t, canonical bool) {
 	emitter.canonical = canonical
-}
-
-// Set the indentation increment.
-func yaml_emitter_set_indent(emitter *yaml_emitter_t, indent int) {
-	if indent < 2 || indent > 9 {
-		indent = 2
-	}
-	emitter.best_indent = indent
 }
 
 // Set the preferred line width.

--- a/emitterc.go
+++ b/emitterc.go
@@ -241,7 +241,7 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 			emitter.indent += 2
 		} else {
 			// Everything else aligns to the chosen indentation.
-			emitter.indent = emitter.best_indent*((emitter.indent+emitter.best_indent)/emitter.best_indent)
+			emitter.indent = emitter.best_indent * ((emitter.indent + emitter.best_indent) / emitter.best_indent)
 		}
 	}
 	return true
@@ -1847,7 +1847,7 @@ func yaml_emitter_write_double_quoted_scalar(emitter *yaml_emitter_t, value []by
 
 func yaml_emitter_write_block_scalar_hints(emitter *yaml_emitter_t, value []byte) bool {
 	if is_space(value, 0) || is_break(value, 0) {
-		indent_hint := []byte{'0' + byte(emitter.best_indent)}
+		indent_hint := []byte{'0' + byte(emitter.indent)}
 		if !yaml_emitter_write_indicator(emitter, indent_hint, false, false, false) {
 			return false
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -392,6 +392,13 @@ var marshalTests = []struct {
 		"a: \"2015-02-24T18:19:39Z\"\n",
 	},
 
+	// Ensure correct indentation.
+	// https://github.com/go-yaml/yaml/issues/643
+	{
+		[]string{" hello\nworld"},
+		"- |2-\n   hello\n  world\n",
+	},
+
 	// Ensure strings containing ": " are quoted (reported as PR #43, but not reproducible).
 	{
 		map[string]string{"a": "b: c"},

--- a/encode_test.go
+++ b/encode_test.go
@@ -514,6 +514,26 @@ func (s *S) TestMarshal(c *C) {
 	}
 }
 
+func (s *S) TestScalarIndentIndicator(c *C) {
+	// Tests: https://github.com/go-yaml/yaml/issues/643.
+	var buf bytes.Buffer
+
+	for i := 1; i < 9; i++ {
+		c.Logf("test %d", i)
+
+		buf.Reset()
+
+		enc := yaml.NewEncoder(&buf)
+		enc.SetIndent(i)
+
+		err := enc.Encode([]string{" hello\nworld"})
+		c.Assert(err, IsNil)
+
+		err = yaml.Unmarshal(buf.Bytes(), &[]string{})
+		c.Assert(err, IsNil)
+	}
+}
+
 func (s *S) TestEncoderSingleDocument(c *C) {
 	for i, item := range marshalTests {
 		c.Logf("test %d. %q", i, item.data)

--- a/encode_test.go
+++ b/encode_test.go
@@ -399,6 +399,99 @@ var marshalTests = []struct {
 		"- |2-\n   hello\n  world\n",
 	},
 
+	{
+		struct{ Value []string }{[]string{`
+
+line 1
+	line 2
+
+	line 3
+
+`}},
+		"" +
+			"value:\n" +
+			"    - |2+\n\n" +
+			"      line 1\n" +
+			"      \tline 2\n" +
+			"\n" +
+			"      \tline 3\n" +
+			"\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\nline1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"      line1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\n line1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"       line1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\n  line1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"        line1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\n\tline1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"      \tline1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\n line1\nline2\n  line3\n   line4"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"       line1\n" +
+			"      line2\n" +
+			"        line3\n" +
+			"         line4\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{" line1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"       line1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"  line1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |2-\n" +
+			"        line1\n" +
+			"      line2\n",
+	},
+
+	{
+		struct{ Value []string }{[]string{"\tline1\nline2"}},
+		"" +
+			"value:\n" +
+			"    - |-\n" +
+			"      \tline1\n" +
+			"      line2\n",
+	},
+
 	// Ensure strings containing ": " are quoted (reported as PR #43, but not reproducible).
 	{
 		map[string]string{"a": "b: c"},
@@ -527,9 +620,6 @@ func (s *S) TestScalarIndentIndicator(c *C) {
 		enc.SetIndent(i)
 
 		err := enc.Encode([]string{" hello\nworld"})
-		c.Assert(err, IsNil)
-
-		err = yaml.Unmarshal(buf.Bytes(), &[]string{})
 		c.Assert(err, IsNil)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.18
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module gopkg.in/yaml.v3
+module "gopkg.in/yaml.v3"
 
-go 1.18
-
-require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/suite_test.go
+++ b/suite_test.go
@@ -16,8 +16,9 @@
 package yaml_test
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
Fixes #643

The library can produce invalid YAML (`yaml.Marshal([]string{" hello\nworld"})`):
```yaml
- |4-
   hello
  world
```

The indention is `2`, but the indicator shows `4-`.

This PR fixes this behaviour.