### PR TITLE
Accept int(0) as zero duration

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -627,6 +627,9 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			if !isDuration && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				return true
+			} else if isDuration && resolved == 0 {
+				out.SetInt(0)
+				return true
 			}
 		case int64:
 			if !isDuration && !out.OverflowInt(resolved) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -618,6 +618,18 @@ var unmarshalTests = []struct {
 		map[string]time.Duration{"a": 3 * time.Second},
 	},
 
+	// Zero duration as a string.
+	{
+		"a: '0'",
+		map[string]time.Duration{"a": 0},
+	},
+
+	// Zero duration as an int.
+	{
+		"a: 0",
+		map[string]time.Duration{"a": 0},
+	},
+
 	// Issue #24.
 	{
 		"a: <foo>",


### PR DESCRIPTION
While in https://github.com/go-yaml/yaml/issues/200 it was correctly stated that durations without units are misleading, there's an exception to that: zero duration.

This is a special case in time.Duration.ParseDuration(): https://github.com/golang/go/blob/176b63e7113b82c140a4ecb2620024526c2c42e3/src/time/format.go#L1536-L1539

And supporting this improves backwards compatibility with YAMLs written for v2, as its very common to write just a zero for zero duration (especially because this works for other config-parsing sources like flags).

(Note that `"0"` was already supported as valid `time.Duration`, we just add support for `0` here)