### PR TITLE
V2: fix: Support escaped slash in strings

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -734,6 +734,15 @@ b:
 				"a": "a",
 			}},
 	},
+
+	// Issue #797 - escaped slash
+	{
+		"a: \"\\/\"\nb: /",
+		map[string]interface{}{
+			"a": "/",
+			"b": "/",
+		},
+	},
 }
 
 type M map[interface{}]interface{}

--- a/scannerc.go
+++ b/scannerc.go
@@ -2422,6 +2422,10 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 					code_length = 4
 				case 'U':
 					code_length = 8
+				case '/':
+					// Support escaped slash ("\/"), as required by YAML 1.2.0+
+					// for strict JSON compatibility
+					s = append(s, '/')
 				default:
 					yaml_parser_set_scanner_error(parser, "while parsing a quoted scalar",
 						start_mark, "found unknown escape character")


### PR DESCRIPTION
> Fixes https://github.com/go-yaml/yaml/issues/797
> 
> The JSON spec lists the / character as optionally-escapable, and so YAML v1.2.0 added support for the sequence \/ to be unescaped to /.
> 
> This PR adds the minimum necessary support for this, and should solve the issues that a few people have already hit, as documented in https://github.com/go-yaml/yaml/issues/797.

This is a git cherry-pick of @hairyhenderson's PR #862, but targeted for the V2 branch. See his PR for the V3 fix.