### PR TITLE
fix incorrect comparison of mapping keys

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -772,8 +772,8 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 			ni := n.Content[i]
 			for j := i + 2; j < l; j += 2 {
 				nj := n.Content[j]
-				if ni.Kind == nj.Kind && ni.Value == nj.Value {
-					d.terrors = append(d.terrors, fmt.Sprintf("line %d: mapping key %#v already defined at line %d", nj.Line, nj.Value, ni.Line))
+				if ni.Equal(nj) {
+					d.terrors = append(d.terrors, fmt.Sprintf("line %d: mapping key already defined at line %d", nj.Line, ni.Line))
 				}
 			}
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -802,6 +802,40 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
+
+	// Explicit mapping keys
+	{
+		"?\n  K1\n: V1",
+		map[string]string{
+			"K1": "V1",
+		},
+	},
+	{
+		"?\n  a: A1\n  b: B1\n: V1",
+		map[struct{ A, B string }]string{
+			{"A1", "B1"}: "V1",
+		},
+	},
+	{
+		"?\n  - A1\n  - B1\n: V1",
+		map[[2]string]string{
+			{"A1", "B1"}: "V1",
+		},
+	},
+	{
+		"?\n  a: A1\n  b: B1\n: V1\n?\n  a: A2\n  b: B2\n: V2",
+		map[struct{ A, B string }]string{
+			{"A1", "B1"}: "V1",
+			{"A2", "B2"}: "V2",
+		},
+	},
+	{
+		"?\n  - A1\n  - B1\n: V1\n?\n  - A2\n  - B2\n: V2",
+		map[[2]string]string{
+			{"A1", "B1"}: "V1",
+			{"A2", "B2"}: "V2",
+		},
+	},
 }
 
 type M map[string]interface{}
@@ -947,7 +981,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -961,6 +995,7 @@ var unmarshalErrorTests = []struct {
 			"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
 		"yaml: document contains excessive aliasing",
 	},
+	{"?\n  a: A1\n  b: B1\n: V1\n?\n  a: A1\n  b: B1\n: V2", "yaml: unmarshal errors:\n  line 6: mapping key already defined at line 2"},
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {
@@ -1482,7 +1517,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1533,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1551,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,

--- a/decode_test.go
+++ b/decode_test.go
@@ -1658,7 +1658,7 @@ var unmarshalStrictTests = []struct {
 	unique: true,
 	data:   "a: 1\nb: 2\na: 3\n",
 	value:  struct{ A, B int }{A: 3, B: 2},
-	error:  `yaml: unmarshal errors:\n  line 3: mapping key "a" already defined at line 1`,
+	error:  `yaml: unmarshal errors:\n  line 3: mapping key already defined at line 1`,
 }, {
 	unique: true,
 	data:   "c: 3\na: 1\nb: 2\nc: 4\n",
@@ -1674,7 +1674,7 @@ var unmarshalStrictTests = []struct {
 			},
 		},
 	},
-	error: `yaml: unmarshal errors:\n  line 4: mapping key "c" already defined at line 1`,
+	error: `yaml: unmarshal errors:\n  line 4: mapping key already defined at line 1`,
 }, {
 	unique: true,
 	data:   "c: 0\na: 1\nb: 2\nc: 1\n",
@@ -1690,7 +1690,7 @@ var unmarshalStrictTests = []struct {
 			},
 		},
 	},
-	error: `yaml: unmarshal errors:\n  line 4: mapping key "c" already defined at line 1`,
+	error: `yaml: unmarshal errors:\n  line 4: mapping key already defined at line 1`,
 }, {
 	unique: true,
 	data:   "c: 1\na: 1\nb: 2\nc: 3\n",
@@ -1704,7 +1704,7 @@ var unmarshalStrictTests = []struct {
 			"c": 3,
 		},
 	},
-	error: `yaml: unmarshal errors:\n  line 4: mapping key "c" already defined at line 1`,
+	error: `yaml: unmarshal errors:\n  line 4: mapping key already defined at line 1`,
 }, {
 	unique: true,
 	data:   "a: 1\n9: 2\nnull: 3\n9: 4",
@@ -1713,7 +1713,7 @@ var unmarshalStrictTests = []struct {
 		nil: 3,
 		9:   4,
 	},
-	error: `yaml: unmarshal errors:\n  line 4: mapping key "9" already defined at line 2`,
+	error: `yaml: unmarshal errors:\n  line 4: mapping key already defined at line 2`,
 }}
 
 func (s *S) TestUnmarshalKnownFields(c *C) {

--- a/yaml.go
+++ b/yaml.go
@@ -363,7 +363,7 @@ const (
 //             Address yaml.Node
 //     }
 //     err := yaml.Unmarshal(data, &person)
-// 
+//
 // Or by itself:
 //
 //     var person Node
@@ -373,7 +373,7 @@ type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -421,6 +421,28 @@ func (n *Node) IsZero() bool {
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
 
+// Equal returns whether the node is equal to another node by the node comparison spec
+func (n *Node) Equal(o *Node) bool {
+	if n.Kind != o.Kind || n.Tag != o.Tag {
+		return false
+	}
+	switch n.Kind {
+	case ScalarNode:
+		return n.Value == o.Value
+	case SequenceNode, MappingNode:
+		if len(n.Content) != len(o.Content) {
+			return false
+		}
+		for i := range n.Content {
+			if !n.Content[i].Equal(o.Content[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed


### PR DESCRIPTION
```golang
import (
	"gopkg.in/yaml.v3"
	"testing"
)

type testStruct struct {
	A string
	B string
}

func Test(t *testing.T) {
	input := []byte(`
?
  a: A1
  b: B1
: value1
?
  a: A2
  b: B2
: value2
`)
	var output map[testStruct]string
	err := yaml.Unmarshal(input, output)
	if err != nil {
		panic(err)
	}
}
```

The above test fails because mapping keys that are themselves mappings or sequences are not compared correctly.

[The correct method is defined here in the YAML spec.](https://yaml.org/spec/1.2.2/#node-comparison)

This PR implements that method and replaces the comparison.

[Matching issue over here](https://github.com/go-yaml/yaml/issues/890)