### PR TITLE
Allow question marks in plain scalars in flow collections

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -802,6 +802,15 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
+
+	// Question mark in plain scalar flow collection
+	{
+		"seq: [a?b]",
+		map[string]interface{}{"seq": []interface{}{"a?b"}},
+	}, {
+		"map: {a: b?c}",
+		map[string]interface{}{"map": map[string]interface{}{"a": "b?c"}},
+	},
 }
 
 type M map[string]interface{}

--- a/scannerc.go
+++ b/scannerc.go
@@ -2726,7 +2726,7 @@ func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) b
 			if (parser.buffer[parser.buffer_pos] == ':' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
 				(parser.flow_level > 0 &&
 					(parser.buffer[parser.buffer_pos] == ',' ||
-						parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == '[' ||
+						parser.buffer[parser.buffer_pos] == '[' ||
 						parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
 						parser.buffer[parser.buffer_pos] == '}')) {
 				break


### PR DESCRIPTION
Allow question marks in plain scalars in flow collections

According to the YAML 1.1 spec question marks can be allowed in plain scalars that appear in flow collections.

This PR copies the changes from https://github.com/yaml/libyaml/pull/105 to allow for question marks to appear in the middle of plain flow scalars.
As the original PR states this doesn't allow for `?foo` yet even though that is valid according to the YAML spec.
