### PR TITLE
Make possible to implement Unmarshaler for map types.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -417,8 +417,11 @@ func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unm
 			out = out.Elem()
 			again = true
 		}
-		if out.CanAddr() {
-			outi := out.Addr().Interface()
+		if out.CanInterface() || out.CanAddr() {
+			outi := out.Interface()
+			if out.CanAddr() {
+				outi = out.Addr().Interface()
+			}
 			if u, ok := outi.(Unmarshaler); ok {
 				good = d.callUnmarshaler(n, u)
 				return out, true, good

--- a/decode_test.go
+++ b/decode_test.go
@@ -1708,7 +1708,7 @@ type stringSetUnmarshaler map[string]struct{}
 func (s stringSetUnmarshaler) UnmarshalYAML(value *yaml.Node) error {
 	values := make([]string, 0, len(value.Content))
 
-	if err := value.Decode(values); err != nil {
+	if err := value.Decode(&values); err != nil {
 		return err
 	}
 
@@ -1725,10 +1725,8 @@ func (s stringSetUnmarshaler) UnmarshalYAML(value *yaml.Node) error {
 
 func (s *S) TestStringSetUnmarshaler(c *C) {
 	cases := []string{
-		"a:\nb:\nc:",
 		"- a\n- b\n- c",
 		"[a, b, c]",
-		"{a: null, b: null, c: null}",
 	}
 
 	for _, data := range cases {

--- a/decode_test.go
+++ b/decode_test.go
@@ -947,7 +947,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -1482,7 +1482,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1498,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1516,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,
@@ -1700,6 +1700,46 @@ func (s *S) TestUnmarshalKnownFields(c *C) {
 		dec.KnownFields(item.known)
 		err := dec.Decode(value.Interface())
 		c.Assert(err, ErrorMatches, item.error)
+	}
+}
+
+type stringSetUnmarshaler map[string]struct{}
+
+func (s stringSetUnmarshaler) UnmarshalYAML(value *yaml.Node) error {
+	values := make([]string, 0, len(value.Content))
+
+	if err := value.Decode(values); err != nil {
+		return err
+	}
+
+	for v, _ := range s {
+		delete(s, v)
+	}
+
+	for _, v := range values {
+		s[v] = struct{}{}
+	}
+
+	return nil
+}
+
+func (s *S) TestStringSetUnmarshaler(c *C) {
+	cases := []string{
+		"a:\nb:\nc:",
+		"- a\n- b\n- c",
+		"[a, b, c]",
+		"{a: null, b: null, c: null}",
+	}
+
+	for _, data := range cases {
+		v := stringSetUnmarshaler{}
+		err := yaml.Unmarshal([]byte(data), v)
+		c.Assert(err, Equals, nil)
+		c.Assert(v, DeepEquals, stringSetUnmarshaler{
+			"a": struct{}{},
+			"b": struct{}{},
+			"c": struct{}{},
+		})
 	}
 }
 


### PR DESCRIPTION
The more-or-less canonical way to implement set data structure in go is by using `map[key]struc{}` type. That type can implement `Marshaler`/`Unmarshaler` interfaces to define custom marshaling (into a sequence of items, for example). Unfortunatelly, current code does not try to check if map type implements `Unmarshaler` interface because map is not addressable.

Simple snippet to check it:

```
package main
import "gopkg.in/yaml.v3"

type stringSet map[string]struct{}

// Marshaler implementation marshals this type as sequence. This part works flawlessly
func (s stringSet) MarshalYAML() (interface{}, error) {
  values := make([]string, 0, len(s))
  for v, _ := range s {
    values = append(values, v)
  }
  return values
}

// Unmarshaler implementation is not called during unmarshaling.
func (s stringSet) UnmarshalYAML(value *yaml.Node) error {
  values  := make([]string, 0, len(value.Content))
  if err := value.Decode(&values); err != nil {
    return err
  }
  newSet := make(map[string]struct{}, 0, len(values))
  for _, v := range values {
    newSet[v] = struct{}{}
  }
  s = newSet
  return nil
}

func main() {
  set := stringSet{}
  data := "[a, b, c]"
  if err := yaml.Unmarshal([]byte(data), set); err != nil {
    // Currently returns: yaml: unmarshal errors:
    //      line 1: cannot unmarshal !!seq into main.stringSet
    panic(err)
  }
}
```

This pull-request:
1. Adds a very specific test which is almost the same as snippet before. If you run tests on the first commit of the PR, that tests fails.
2. Slightly changes logic of `decoder.prepare` function. Now that function tries to cast a reflected value to `Unmarshaler` interface even if it is not addressable. That allows calling UnmarshalYAML on map types.