### PR TITLE
Add String() methods to Kind and Style types

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -330,6 +330,24 @@ const (
 	AliasNode
 )
 
+// String returns the string representation of the node kind
+func (k Kind) String() string {
+	switch k {
+	case DocumentNode:
+		return "document"
+	case SequenceNode:
+		return "sequence"
+	case MappingNode:
+		return "mapping"
+	case ScalarNode:
+		return "scalar"
+	case AliasNode:
+		return "alias"
+	default:
+		return "unknown"
+	}
+}
+
 type Style uint32
 
 const (
@@ -340,6 +358,26 @@ const (
 	FoldedStyle
 	FlowStyle
 )
+
+// String returns the string representation of the node style
+func (s Style) String() string {
+	switch s {
+	case TaggedStyle:
+		return "tagged"
+	case DoubleQuotedStyle:
+		return "double-quoted"
+	case SingleQuotedStyle:
+		return "single-quoted"
+	case LiteralStyle:
+		return "literal"
+	case FoldedStyle:
+		return "folded"
+	case FlowStyle:
+		return "flow"
+	default:
+		return "unknown"
+	}
+}
 
 // Node represents an element in the YAML document hierarchy. While documents
 // are typically encoded and decoded into higher level types, such as structs


### PR DESCRIPTION
We found that when debugging, it's difficult to know what Kind/Style different nodes are (see: https://github.com/buildkite/agent/pull/1930#discussion_r1090068650) without looking at the source code and going through the iotas.

This PR adds `String()` methods to both the kind and the type structs, such that they fulfil the `Stringer` interface, and so can be printed in a human-readable way using the `%v` Printf verb.