### PR TITLE
Set top-level minimal permissions on Github workflows

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,6 +1,8 @@
 ---
 name: Go
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     name: Test


### PR DESCRIPTION
It secures the repo against erroneous or malicious actions from external jobs called from the workflow. It's specially important for the case they get compromised, for example.

Closes #941 