### PR TITLE
decode: check for interface and comparable

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -831,11 +831,13 @@ func (d *decoder) mapping(n *Node, out reflect.Value) (good bool) {
 		k := reflect.New(kt).Elem()
 		if d.unmarshal(n.Content[i], k) {
 			if mergedFields != nil {
-				ki := k.Interface()
-				if mergedFields[ki] {
-					continue
+				if k.CanInterface() && k.Comparable() {
+					ki := k.Interface()
+					if mergedFields[ki] {
+						continue
+					}
+					mergedFields[ki] = true
 				}
-				mergedFields[ki] = true
 			}
 			kkind := k.Kind()
 			if kkind == reflect.Interface {

--- a/decode_test.go
+++ b/decode_test.go
@@ -947,7 +947,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -1482,7 +1482,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1498,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1516,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,
@@ -1734,6 +1734,9 @@ func (s *S) TestFuzzCrashers(c *C) {
 		"? \ufeff:\n",
 		"0: \ufeff\n",
 		"? \ufeff: \ufeff\n",
+
+		// panic: runtime error: hash of unhashable type map[interface {}]interface {}
+		"?\n<<:\n ? 0:",
 	}
 	for _, data := range cases {
 		var v interface{}


### PR DESCRIPTION
Closes #932 

Adds a safety check for the reflect type to ensure that it is capable of interfacing, and is comparable to safely use as a map key.