### PR TITLE
Do not panic to outside

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -23,6 +23,7 @@
 package yaml
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -77,7 +78,7 @@ func yaml_reader_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err 
 // Set a string input.
 func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
 	if parser.read_handler != nil {
-		panic("must set the input source only once")
+		panic(yamlInternalError{fmt.Errorf("must set the input source only once")})
 	}
 	parser.read_handler = yaml_string_read_handler
 	parser.input = input
@@ -87,7 +88,7 @@ func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
 // Set a file input.
 func yaml_parser_set_input_reader(parser *yaml_parser_t, r io.Reader) {
 	if parser.read_handler != nil {
-		panic("must set the input source only once")
+		panic(yamlInternalError{fmt.Errorf("must set the input source only once")})
 	}
 	parser.read_handler = yaml_reader_read_handler
 	parser.input_reader = r
@@ -96,7 +97,7 @@ func yaml_parser_set_input_reader(parser *yaml_parser_t, r io.Reader) {
 // Set the source encoding.
 func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
 	if parser.encoding != yaml_ANY_ENCODING {
-		panic("must set the encoding only once")
+		panic(yamlInternalError{fmt.Errorf("must set the encoding only once")})
 	}
 	parser.encoding = encoding
 }
@@ -133,7 +134,7 @@ func yaml_writer_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
 // Set a string output.
 func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]byte) {
 	if emitter.write_handler != nil {
-		panic("must set the output target only once")
+		panic(yamlInternalError{fmt.Errorf("must set the output target only once")})
 	}
 	emitter.write_handler = yaml_string_write_handler
 	emitter.output_buffer = output_buffer
@@ -142,7 +143,7 @@ func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]by
 // Set a file output.
 func yaml_emitter_set_output_writer(emitter *yaml_emitter_t, w io.Writer) {
 	if emitter.write_handler != nil {
-		panic("must set the output target only once")
+		panic(yamlInternalError{fmt.Errorf("must set the output target only once")})
 	}
 	emitter.write_handler = yaml_writer_write_handler
 	emitter.output_writer = w
@@ -151,7 +152,7 @@ func yaml_emitter_set_output_writer(emitter *yaml_emitter_t, w io.Writer) {
 // Set the output encoding.
 func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t) {
 	if emitter.encoding != yaml_ANY_ENCODING {
-		panic("must set the output encoding only once")
+		panic(yamlInternalError{fmt.Errorf("must set the output encoding only once")})
 	}
 	emitter.encoding = encoding
 }

--- a/decode.go
+++ b/decode.go
@@ -41,7 +41,7 @@ type parser struct {
 func newParser(b []byte) *parser {
 	p := parser{}
 	if !yaml_parser_initialize(&p.parser) {
-		panic("failed to initialize YAML emitter")
+		panic(yamlInternalError{fmt.Errorf("failed to initialize YAML emitter")})
 	}
 	if len(b) == 0 {
 		b = []byte{'\n'}
@@ -53,7 +53,7 @@ func newParser(b []byte) *parser {
 func newParserFromReader(r io.Reader) *parser {
 	p := parser{}
 	if !yaml_parser_initialize(&p.parser) {
-		panic("failed to initialize YAML emitter")
+		panic(yamlInternalError{fmt.Errorf("failed to initialize YAML emitter")})
 	}
 	yaml_parser_set_input_reader(&p.parser, r)
 	return &p
@@ -161,9 +161,9 @@ func (p *parser) parse() *Node {
 		// Happens when attempting to decode an empty buffer.
 		return nil
 	case yaml_TAIL_COMMENT_EVENT:
-		panic("internal error: unexpected tail comment event (please report)")
+		panic(yamlInternalError{fmt.Errorf("internal error: unexpected tail comment event (please report)")})
 	default:
-		panic("internal error: attempted to parse unknown event (please report): " + p.event.typ.String())
+		panic(yamlInternalError{fmt.Errorf("internal error: attempted to parse unknown event (please report): " + p.event.typ.String())})
 	}
 }
 
@@ -713,7 +713,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			return true
 		}
 	case reflect.Ptr:
-		panic("yaml internal error: please report the issue")
+		panic(yamlInternalError{fmt.Errorf("yaml internal error: please report the issue")})
 	}
 	d.terror(n, tag, out)
 	return false
@@ -878,7 +878,7 @@ func isStringMap(n *Node) bool {
 func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
 	sinfo, err := getStructInfo(out.Type())
 	if err != nil {
-		panic(err)
+		panic(yamlInternalError{err})
 	}
 
 	var inlineMap reflect.Value

--- a/emitterc.go
+++ b/emitterc.go
@@ -63,7 +63,7 @@ func put_break(emitter *yaml_emitter_t) bool {
 		emitter.buffer[emitter.buffer_pos+1] = '\n'
 		emitter.buffer_pos += 2
 	default:
-		panic("unknown line break setting")
+		panic(yamlInternalError{fmt.Errorf("unknown line break setting")})
 	}
 	if emitter.column == 0 {
 		emitter.space_above = true
@@ -95,7 +95,7 @@ func write(emitter *yaml_emitter_t, s []byte, i *int) bool {
 	case 1:
 		emitter.buffer[p+0] = s[*i+0]
 	default:
-		panic("unknown character width")
+		panic(yamlInternalError{fmt.Errorf("unknown character width")})
 	}
 	emitter.column++
 	emitter.buffer_pos += w
@@ -311,7 +311,7 @@ func yaml_emitter_state_machine(emitter *yaml_emitter_t, event *yaml_event_t) bo
 	case yaml_EMIT_END_STATE:
 		return yaml_emitter_set_emitter_error(emitter, "expected nothing after STREAM-END")
 	}
-	panic("invalid emitter state")
+	panic(yamlInternalError{fmt.Errorf("invalid emitter state")})
 }
 
 // Expect STREAM-START.
@@ -1111,7 +1111,7 @@ func yaml_emitter_process_scalar(emitter *yaml_emitter_t) bool {
 	case yaml_FOLDED_SCALAR_STYLE:
 		return yaml_emitter_write_folded_scalar(emitter, emitter.scalar_data.value)
 	}
-	panic("unknown scalar style")
+	panic(yamlInternalError{fmt.Errorf("unknown scalar style")})
 }
 
 // Write a head comment.

--- a/encode.go
+++ b/encode.go
@@ -179,7 +179,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 	case reflect.Bool:
 		e.boolv(tag, in)
 	default:
-		panic("cannot marshal type: " + in.Type().String())
+		panic(yamlInternalError{fmt.Errorf("cannot marshal type: %s", in.Type().String())})
 	}
 }
 
@@ -214,7 +214,7 @@ func (e *encoder) fieldByIndex(v reflect.Value, index []int) (field reflect.Valu
 func (e *encoder) structv(tag string, in reflect.Value) {
 	sinfo, err := getStructInfo(in.Type())
 	if err != nil {
-		panic(err)
+		panic(yamlInternalError{err})
 	}
 	e.mappingv(tag, func() {
 		for _, info := range sinfo.FieldsList {
@@ -242,7 +242,7 @@ func (e *encoder) structv(tag string, in reflect.Value) {
 				sort.Sort(keys)
 				for _, k := range keys {
 					if _, found := sinfo.FieldsMap[k.String()]; found {
-						panic(fmt.Sprintf("cannot have key %q in inlined map: conflicts with struct field", k.String()))
+						panic(yamlInternalError{fmt.Errorf("cannot have key %q in inlined map: conflicts with struct field", k.String())})
 					}
 					e.marshal("", k)
 					e.flow = false

--- a/encode_test.go
+++ b/encode_test.go
@@ -545,31 +545,26 @@ func (errorWriter) Write([]byte) (int, error) {
 }
 
 var marshalErrorTests = []struct {
-	value interface{}
-	error string
-	panic string
+	value    interface{}
+	errorMsg string
 }{{
 	value: &struct {
 		B       int
 		inlineB ",inline"
 	}{1, inlineB{2, inlineC{3}}},
-	panic: `duplicated key 'b' in struct struct \{ B int; .*`,
+	errorMsg: `duplicated key 'b' in struct struct \{ B int; .*`,
 }, {
 	value: &struct {
 		A int
 		B map[string]int ",inline"
 	}{1, map[string]int{"a": 2}},
-	panic: `cannot have key "a" in inlined map: conflicts with struct field`,
+	errorMsg: `cannot have key "a" in inlined map: conflicts with struct field`,
 }}
 
 func (s *S) TestMarshalErrors(c *C) {
 	for _, item := range marshalErrorTests {
-		if item.panic != "" {
-			c.Assert(func() { yaml.Marshal(item.value) }, PanicMatches, item.panic)
-		} else {
-			_, err := yaml.Marshal(item.value)
-			c.Assert(err, ErrorMatches, item.error)
-		}
+		_, err := yaml.Marshal(item.value)
+		c.Assert(err, ErrorMatches, item.errorMsg)
 	}
 }
 

--- a/parserc.go
+++ b/parserc.go
@@ -24,6 +24,7 @@ package yaml
 
 import (
 	"bytes"
+	"fmt"
 )
 
 // The parser implements the following grammar:
@@ -221,7 +222,7 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 		return yaml_parser_parse_flow_mapping_value(parser, event, true)
 
 	default:
-		panic("invalid parser state")
+		panic(yamlInternalError{fmt.Errorf("invalid parser state")})
 	}
 }
 

--- a/readerc.go
+++ b/readerc.go
@@ -23,6 +23,7 @@
 package yaml
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -112,7 +113,7 @@ func yaml_parser_update_raw_buffer(parser *yaml_parser_t) bool {
 // The length is supposed to be significantly less that the buffer size.
 func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 	if parser.read_handler == nil {
-		panic("read handler must be set")
+		panic(yamlInternalError{fmt.Errorf("read handler must be set")})
 	}
 
 	// [Go] This function was changed to guarantee the requested length size at EOF.
@@ -358,7 +359,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 				}
 
 			default:
-				panic("impossible")
+				panic(yamlInternalError{fmt.Errorf("impossible")})
 			}
 
 			// Check if the character is in the allowed range:

--- a/resolve.go
+++ b/resolve.go
@@ -17,6 +17,7 @@ package yaml
 
 import (
 	"encoding/base64"
+	"fmt"
 	"math"
 	"regexp"
 	"strconv"
@@ -258,7 +259,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 				}
 			}
 		default:
-			panic("internal error: missing handler for resolver table: " + string(rune(hint)) + " (with " + in + ")")
+			panic(yamlInternalError{fmt.Errorf("internal error: missing handler for resolver table: %s (with %s)", string(rune(hint)), in)})
 		}
 	}
 	return strTag, in

--- a/scannerc.go
+++ b/scannerc.go
@@ -545,7 +545,7 @@ func read(parser *yaml_parser_t, s []byte) []byte {
 	}
 	w := width(parser.buffer[parser.buffer_pos])
 	if w == 0 {
-		panic("invalid character sequence")
+		panic(yamlInternalError{fmt.Errorf("invalid character sequence")})
 	}
 	if len(s) == 0 {
 		s = make([]byte, 0, 32)

--- a/sorter.go
+++ b/sorter.go
@@ -16,6 +16,7 @@
 package yaml
 
 import (
+	"fmt"
 	"reflect"
 	"unicode"
 )
@@ -130,5 +131,5 @@ func numLess(a, b reflect.Value) bool {
 	case reflect.Bool:
 		return !a.Bool() && b.Bool()
 	}
-	panic("not a number")
+	panic(yamlInternalError{fmt.Errorf("not a number")})
 }

--- a/writerc.go
+++ b/writerc.go
@@ -22,6 +22,8 @@
 
 package yaml
 
+import "fmt"
+
 // Set the writer error and return false.
 func yaml_emitter_set_writer_error(emitter *yaml_emitter_t, problem string) bool {
 	emitter.error = yaml_WRITER_ERROR
@@ -32,7 +34,7 @@ func yaml_emitter_set_writer_error(emitter *yaml_emitter_t, problem string) bool
 // Flush the output buffer.
 func yaml_emitter_flush(emitter *yaml_emitter_t) bool {
 	if emitter.write_handler == nil {
-		panic("write handler not set")
+		panic(yamlInternalError{fmt.Errorf("write handler not set")})
 	}
 
 	// Check if the buffer is empty.

--- a/yaml.go
+++ b/yaml.go
@@ -273,7 +273,7 @@ func (n *Node) Encode(v interface{}) (err error) {
 // SetIndent changes the used indentation used when encoding.
 func (e *Encoder) SetIndent(spaces int) {
 	if spaces < 0 {
-		panic("yaml: cannot indent to a negative number of spaces")
+		panic(yamlInternalError{fmt.Errorf("yaml: cannot indent to a negative number of spaces")})
 	}
 	e.encoder.indent = spaces
 }
@@ -290,6 +290,8 @@ func handleErr(err *error) {
 	if v := recover(); v != nil {
 		if e, ok := v.(yamlError); ok {
 			*err = e.err
+		} else if e, ok := v.(yamlInternalError); ok {
+			*err = e.err
 		} else {
 			panic(v)
 		}
@@ -297,6 +299,10 @@ func handleErr(err *error) {
 }
 
 type yamlError struct {
+	err error
+}
+
+type yamlInternalError struct {
 	err error
 }
 


### PR DESCRIPTION
Raise all panics as `yamlInternalError{}` and let `handleErr()` do its job

---

There is one caveat: I had to change [one test](https://github.com/go-yaml/yaml/pull/955/files#diff-4e910d7298506f3c6381637056a8f19515f546f8ed1c882391701e7fbc1f5df3L568) 😢 
I really tried not to, but that test checked for Panic where I deeply believe it should be testing for error.

If you think there is any problem with my PR, please let me know. 
Let's try to build a better world, line by line ❤️ 


closes: #954 

---
also closes this ones:
closes #747
closes #802
closes #803
closes #895
closes #912
closes #919
closes #932
closes #933
closes #944