### PR TITLE
Fix new line on encoding folded style

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -1943,11 +1943,11 @@ func yaml_emitter_write_folded_scalar(emitter *yaml_emitter_t, value []byte) boo
 	for i := 0; i < len(value); {
 		if is_break(value, i) {
 			if !breaks && !leading_spaces && value[i] == '\n' {
-				k := 0
-				for is_break(value, k) {
+				k := i
+				for k < len(value) && is_break(value, k) {
 					k += width(value[k])
 				}
-				if !is_blankz(value, k) {
+				if k < len(value) && !is_blankz(value, k) {
 					if !put_break(emitter) {
 						return false
 					}

--- a/encode_test.go
+++ b/encode_test.go
@@ -456,6 +456,24 @@ var marshalTests = []struct {
 			Style: yaml.SingleQuotedStyle,
 		},
 		"'foo'\n",
+	}, {
+		yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Style: yaml.FoldedStyle,
+			Value: `first line
+  more`,
+		},
+		">-\n    first line\n      more\n",
+	}, {
+		yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Style: yaml.FoldedStyle,
+			Value: `first line
+more`,
+		},
+		">-\n    first line\n\n    more\n",
 	},
 
 	// Enforced tagging with shorthand notation (issue #616).


### PR DESCRIPTION
When using:

```
 >-
   someline
     more

The encoder would emit:

 >-
   someline

     more
```

The issue was introduced in the original translation from C to Go. In the C code the MOVE macro would advance the start pointer of the string. In the Go case "k = 0" points to the start of the string where in the C case it would be the read pointer. Fix it.

Also address bound checks to not go beyond the string (I assume in the C code there is an explicit NUL or at least some NUL).

Fixes: #804