### PR TITLE
Unmarshal scalar binary data into `[]byte` 

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -615,6 +615,13 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		}
 		out.SetString(n.Value)
 		return true
+	case reflect.Slice:
+		if out.Type().Elem().Kind() == reflect.Uint8 {
+			if tag == binaryTag {
+				out.SetBytes([]byte(resolved.(string)))
+				return true
+			}
+		}
 	case reflect.Interface:
 		out.Set(reflect.ValueOf(resolved))
 		return true

--- a/decode_test.go
+++ b/decode_test.go
@@ -640,6 +640,15 @@ var unmarshalTests = []struct {
 	}, {
 		"a: !!binary |\n  " + strings.Repeat("A", 70) + "\n  ==\n",
 		map[string]string{"a": strings.Repeat("\x00", 52)},
+	}, {
+		"a: !!binary gIGC\n",
+		map[string][]byte{"a": {0x80, 0x81, 0x82}},
+	}, {
+		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
+		map[string][]byte{"a": bytes.Repeat([]byte{0x90}, 54)},
+	}, {
+		"a: !!binary |\n  " + strings.Repeat("A", 70) + "\n  ==\n",
+		map[string][]byte{"a": bytes.Repeat([]byte{0x00}, 52)},
 	},
 
 	// Issue #39.
@@ -947,7 +956,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -1482,7 +1491,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1507,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1525,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,

--- a/encode.go
+++ b/encode.go
@@ -167,7 +167,11 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 	case reflect.Struct:
 		e.structv(tag, in)
 	case reflect.Slice, reflect.Array:
-		e.slicev(tag, in)
+		if in.Type().Elem().Kind() == reflect.Uint8 && (tag == "" || tag == binaryTag) {
+			e.stringv(binaryTag, reflect.ValueOf(encodeBase64(string(in.Bytes()))))
+		} else {
+			e.slicev(tag, in)
+		}
 	case reflect.String:
 		e.stringv(tag, in)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/encode_test.go
+++ b/encode_test.go
@@ -359,6 +359,15 @@ var marshalTests = []struct {
 	}, {
 		map[string]string{"a": strings.Repeat("\x90", 54)},
 		"a: !!binary |\n    " + strings.Repeat("kJCQ", 17) + "kJ\n    CQ\n",
+	}, {
+		map[string][]byte{"a": {0x00}},
+		"a: !!binary AA==\n",
+	}, {
+		map[string][]byte{"a": {0x80, 0x81, 0x82}},
+		"a: !!binary gIGC\n",
+	}, {
+		map[string][]byte{"a": bytes.Repeat([]byte{0x90}, 54)},
+		"a: !!binary |\n    " + strings.Repeat("kJCQ", 17) + "kJ\n    CQ\n",
 	},
 
 	// Encode unicode as utf-8 rather than in escaped form.


### PR DESCRIPTION
The YAML spec supports binary data (http://yaml.org/type/binary.html), however this package decodes and encodes nodes with this tag as strings.
This conflicts with the standard Go type `[]byte` - which is used interchangeably with `string`, especially in the context of binary blobs.

Closes #231 