### PR TITLE
fix(yaml.go): Spelling: colums -> columns

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -347,7 +347,7 @@ const (
 // control over the content being decoded or encoded.
 //
 // It's worth noting that although Node offers access into details such as
-// line numbers, colums, and comments, the content when re-encoded will not
+// line numbers, columns, and comments, the content when re-encoded will not
 // have its original textual representation preserved. An effort is made to
 // render the data plesantly, and to preserve comments near the data they
 // describe, though.


### PR DESCRIPTION
There is a misspelling in the doc comments.