### PR TITLE
Multiple merge

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1530,6 +1530,37 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	c.Assert(testm["outer"], DeepEquals, wantm)
 }
 
+const doubleMerge = `
+one: &one
+  a: 1
+  b: 2
+  d: 5
+
+two: &two
+  b: 3
+  c: 4
+  e: 6
+
+merged:
+  a: 0
+  <<: *one
+  <<: *two
+  e: 7
+`
+
+func (s *S) TestDoubleMerge(c *C) {
+	var m map[string]interface{}
+	err := yaml.Unmarshal([]byte(doubleMerge), &m)
+	c.Assert(err, IsNil)
+	c.Assert(m["merged"], DeepEquals, map[string]interface{}{
+		"a": 0, // The value of the parent is preserved over what's brought in by the merge
+		"b": 3,
+		"c": 4,
+		"d": 5,
+		"e": 7,
+	})
+}
+
 var unmarshalNullTests = []struct {
 	input              string
 	pristine, expected func() interface{}

--- a/decode_test.go
+++ b/decode_test.go
@@ -209,13 +209,13 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"seq": []interface{}{"A", "B"}},
 	}, {
 		"seq: [A,B,C,]",
-		map[string][]string{"seq": []string{"A", "B", "C"}},
+		map[string][]string{"seq": {"A", "B", "C"}},
 	}, {
 		"seq: [A,1,C]",
-		map[string][]string{"seq": []string{"A", "1", "C"}},
+		map[string][]string{"seq": {"A", "1", "C"}},
 	}, {
 		"seq: [A,1,C]",
-		map[string][]int{"seq": []int{1}},
+		map[string][]int{"seq": {1}},
 	}, {
 		"seq: [A,1,C]",
 		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
@@ -226,13 +226,13 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"seq": []interface{}{"A", "B"}},
 	}, {
 		"seq:\n - A\n - B\n - C",
-		map[string][]string{"seq": []string{"A", "B", "C"}},
+		map[string][]string{"seq": {"A", "B", "C"}},
 	}, {
 		"seq:\n - A\n - 1\n - C",
-		map[string][]string{"seq": []string{"A", "1", "C"}},
+		map[string][]string{"seq": {"A", "1", "C"}},
 	}, {
 		"seq:\n - A\n - 1\n - C",
-		map[string][]int{"seq": []int{1}},
+		map[string][]int{"seq": {1}},
 	}, {
 		"seq:\n - A\n - 1\n - C",
 		map[string]interface{}{"seq": []interface{}{"A", 1, "C"}},
@@ -453,7 +453,7 @@ var unmarshalTests = []struct {
 		map[interface{}]interface{}{"1": "\"2\""},
 	}, {
 		"v:\n- A\n- 'B\n\n  C'\n",
-		map[string][]string{"v": []string{"A", "B\nC"}},
+		map[string][]string{"v": {"A", "B\nC"}},
 	},
 
 	// Explicit tags.
@@ -657,11 +657,11 @@ var unmarshalTests = []struct {
 	// Support encoding.TextUnmarshaler.
 	{
 		"a: 1.2.3.4\n",
-		map[string]textUnmarshaler{"a": textUnmarshaler{S: "1.2.3.4"}},
+		map[string]textUnmarshaler{"a": {S: "1.2.3.4"}},
 	},
 	{
 		"a: 2015-02-24T18:19:39Z\n",
-		map[string]textUnmarshaler{"a": textUnmarshaler{"2015-02-24T18:19:39Z"}},
+		map[string]textUnmarshaler{"a": {"2015-02-24T18:19:39Z"}},
 	},
 
 	// Timestamps
@@ -947,7 +947,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -1381,7 +1381,7 @@ longTag:
   label: center/big
 
 inlineMap:
-  # Inlined map 
+  # Inlined map
   << : {"x": 1, "y": 2, "r": 10}
   label: center/big
 
@@ -1482,7 +1482,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1498,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1516,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Fixes #966

This PR adds the capability to decode multiple merge nodes on a given document - eg, the document
```Yaml
one: &one
  a: 1
  b: 2

two: &two
  b: 3
  c: 4

merged:
  <<: *one
  <<: *two
```

will now decode to 
```Go
map[string]any{
  "a": 1
  "b": 3
  "c": 4
}
```

where previously, it would have returned an error saying that the `merged` mapping had a duplicate key `<<`.

While this behaviour isn't in the YAML spec (the blessed way to do multiple merges is `<<: [*one, *two]`), it's also not disallowed by it, and many yaml libraries for other languages - notably Python's [pyyaml](https://github.com/yaml/pyyaml) and Ruby's [psych](https://github.com/ruby/psych), which is backed by [libyaml](https://github.com/yaml/libyaml) - do support this behaviour. 

Multiple issues (#966, #918) on this have been raised on this repo before, which leads me to believe that using multiple merge keys is a relatively common expectation to have for a yaml library.