### PR TITLE
better detection of pointer receivers

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 )
 
@@ -110,31 +109,34 @@ func (e *encoder) marshalDoc(tag string, in reflect.Value) {
 
 func (e *encoder) marshal(tag string, in reflect.Value) {
 	tag = shortTag(tag)
-	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
+	if !in.IsValid() { //|| in.Kind() == reflect.Ptr && in.IsNil() {
 		e.nilv()
 		return
 	}
+
 	iface := in.Interface()
+	if iface == nil {
+		e.nilv()
+		return
+	}
+
+	if in.Kind() != reflect.Ptr && in.Kind() != reflect.Interface {
+		if in.CanAddr() {
+			iface = in.Addr().Interface()
+		} else {
+			// uh, not sure about this but look at this project's original Node: case...
+			n := reflect.New(in.Type()).Elem()
+			n.Set(in)
+			iface = n.Addr().Interface()
+		}
+	}
+
 	switch value := iface.(type) {
+	//case *time.Duration:
+	//	e.stringv(tag, reflect.ValueOf(value.String()))
+	//	return
 	case *Node:
 		e.nodev(in)
-		return
-	case Node:
-		if !in.CanAddr() {
-			var n = reflect.New(in.Type()).Elem()
-			n.Set(in)
-			in = n
-		}
-		e.nodev(in.Addr())
-		return
-	case time.Time:
-		e.timev(tag, in)
-		return
-	case *time.Time:
-		e.timev(tag, in.Elem())
-		return
-	case time.Duration:
-		e.stringv(tag, reflect.ValueOf(value.String()))
 		return
 	case Marshaler:
 		v, err := value.MarshalYAML()
@@ -143,20 +145,25 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		}
 		if v == nil {
 			e.nilv()
-			return
+		} else {
+			e.marshal(tag, reflect.ValueOf(v))
 		}
-		e.marshal(tag, reflect.ValueOf(v))
 		return
 	case encoding.TextMarshaler:
 		text, err := value.MarshalText()
 		if err != nil {
 			fail(err)
 		}
-		in = reflect.ValueOf(string(text))
+		e.rawstringv(tag, string(text))
+		return
+	case fmt.Stringer:
+		e.rawstringv(tag, value.String())
+		return
 	case nil:
 		e.nilv()
 		return
 	}
+
 	switch in.Kind() {
 	case reflect.Interface:
 		e.marshal(tag, in.Elem())
@@ -322,8 +329,12 @@ func isOldBool(s string) (result bool) {
 }
 
 func (e *encoder) stringv(tag string, in reflect.Value) {
-	var style yaml_scalar_style_t
 	s := in.String()
+	e.rawstringv(tag, s)
+}
+
+func (e *encoder) rawstringv(tag string, s string) {
+	var style yaml_scalar_style_t
 	canUsePlain := true
 	switch {
 	case !utf8.ValidString(s):
@@ -382,11 +393,13 @@ func (e *encoder) uintv(tag string, in reflect.Value) {
 	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
 }
 
+/* Handled by TextMarshaler in time.Time
 func (e *encoder) timev(tag string, in reflect.Value) {
 	t := in.Interface().(time.Time)
 	s := t.Format(time.RFC3339Nano)
 	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
 }
+*/
 
 func (e *encoder) floatv(tag string, in reflect.Value) {
 	// Issue #352: When formatting, use the precision of the underlying value

--- a/yaml.go
+++ b/yaml.go
@@ -17,8 +17,7 @@
 //
 // Source code and other details for the project are available at GitHub:
 //
-//   https://github.com/go-yaml/yaml
-//
+//	https://github.com/go-yaml/yaml
 package yaml
 
 import (
@@ -75,16 +74,15 @@ type Marshaler interface {
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     var t T
-//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	var t T
+//	yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
 func Unmarshal(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
@@ -185,36 +183,35 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 //
 // The field tag format accepted is:
 //
-//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//	`(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Zero valued structs will be omitted if all their public
-//                  fields are zero, unless they implement an IsZero
-//                  method (see the IsZeroer interface type), in which
-//                  case the field will be excluded if IsZero returns true.
+//	omitempty    Only include the field if it's not set to the zero
+//	             value for the type or to empty slices or maps.
+//	             Zero valued structs will be omitted if all their public
+//	             fields are zero, unless they implement an IsZero
+//	             method (see the IsZeroer interface type), in which
+//	             case the field will be excluded if IsZero returns true.
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps).
+//	flow         Marshal using a flow style (useful for structs,
+//	             sequences and maps).
 //
-//     inline       Inline the field, which must be a struct or a map,
-//                  causing all of its fields or keys to be processed as if
-//                  they were part of the outer struct. For maps, keys must
-//                  not conflict with the yaml keys of other struct fields.
+//	inline       Inline the field, which must be a struct or a map,
+//	             causing all of its fields or keys to be processed as if
+//	             they were part of the outer struct. For maps, keys must
+//	             not conflict with the yaml keys of other struct fields.
 //
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-//
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
@@ -358,22 +355,21 @@ const (
 //
 // For example:
 //
-//     var person struct {
-//             Name    string
-//             Address yaml.Node
-//     }
-//     err := yaml.Unmarshal(data, &person)
-// 
+//	var person struct {
+//	        Name    string
+//	        Address yaml.Node
+//	}
+//	err := yaml.Unmarshal(data, &person)
+//
 // Or by itself:
 //
-//     var person Node
-//     err := yaml.Unmarshal(data, &person)
-//
+//	var person Node
+//	err := yaml.Unmarshal(data, &person)
 type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -420,7 +416,6 @@ func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
-
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed

--- a/yaml.go
+++ b/yaml.go
@@ -654,7 +654,22 @@ type IsZeroer interface {
 
 func isZero(v reflect.Value) bool {
 	kind := v.Kind()
-	if z, ok := v.Interface().(IsZeroer); ok {
+
+	var iface any
+	if kind != reflect.Ptr && kind != reflect.Interface {
+		if v.CanAddr() {
+			iface = v.Addr().Interface()
+		} else {
+			// uh, not sure about this but look at this project's original Node: case...
+			n := reflect.New(v.Type()).Elem()
+			n.Set(v)
+			iface = n.Addr().Interface()
+		}
+	} else {
+		iface = v.Interface()
+	}
+
+	if z, ok := iface.(IsZeroer); ok {
 		if (kind == reflect.Ptr || kind == reflect.Interface) && v.IsNil() {
 			return true
 		}


### PR DESCRIPTION
I did not attempt to fully grok the yaml marshaler implementation but it seems to me to be broken, in the sense that it does not correctly pick up Marshaler implementations that take pointer receivers when a non-pointer struct is marshaled. While at some point the yaml marshaler may want to treat pointers differently from non-pointers (e.g., to create anchors and references), this is not currently a feature so I think "casting" everything to a pointer before doing the type assertion is a valid way to go. time.Time doesn't need a custom marshaler since that type already implements TextMarshaler; and there seemed to be inconsistent handling of Duration and Time pointers vs non-pointers. This is cleaned up in the PR because the "cast" to a pointer folds. I saw other PRs that introduce the ability to set Time formatters etc but I think maybe a more general impl such as passing in a func() that gets called on all types that don't have a Marshaler so as to be able to override the default behavior ...