### PR TITLE
struct_opter

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -649,6 +649,11 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 	return sinfo, nil
 }
 
+// StructOpter
+type StructEncoderOpter interface {
+	OmitAllEmptyFieldsOpt() bool
+}
+
 // IsZeroer is used to check whether an object is zero to
 // determine whether it should be omitted when marshaling
 // with the omitempty flag. One notable implementation


### PR DESCRIPTION
It's a pain to declare every field in a struct as `omitempty` so this allows you to declare a function that tells the encoder to treat all fields that way. The interface can be expanded in the future to specify more "struct wide" options.