### PR TITLE
return !!binary as []byte (but still support String as well)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -575,7 +575,11 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			if err != nil {
 				failf("!!binary value contains invalid base64 data")
 			}
-			resolved = string(data)
+			if out.Kind() == reflect.String {
+				resolved = string(data)
+			} else {
+				resolved = data
+			}
 		}
 	}
 	if resolved == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.20
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module gopkg.in/yaml.v3
+module "gopkg.in/yaml.v3"
 
-go 1.20
-
-require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)


### PR DESCRIPTION
This addresses issue https://github.com/go-yaml/yaml/issues/324

Sorry about the formatting changes in decode_test.go.  My editor does that if I forget to turn it off.  I can remove them if you prefer, but keeping for now, because they are actually fixing the formatting to adhere to the go standard.