### PR TITLE
introduce NewDecoderWithParser with ability to provide a custom parser

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -144,7 +144,7 @@ func (p *parser) anchor(n *Node, anchor []byte) {
 	}
 }
 
-func (p *parser) parse() *Node {
+func (p *parser) Parse() *Node {
 	p.init()
 	switch p.peek() {
 	case yaml_SCALAR_EVENT:
@@ -194,7 +194,7 @@ func (p *parser) node(kind Kind, defaultTag, tag, value string) *Node {
 }
 
 func (p *parser) parseChild(parent *Node) *Node {
-	child := p.parse()
+	child := p.Parse()
 	parent.Content = append(parent.Content, child)
 	return child
 }


### PR DESCRIPTION
this offers user ability to provide yaml document to be decoded into go structs as an abstract `yaml.Node` producer by encapsulating the io.Reader-based `parser` behind a `Parser` interface.

closes https://github.com/go-yaml/yaml/issues/993