### PR TITLE
Clarify the role of io.EOF in Decode

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -114,8 +114,8 @@ func (dec *Decoder) KnownFields(enable bool) {
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v. If there are
 // no more yaml documents to decode (or there never was, for
-// example if the Decoder's io.Reader never had any bytes),
-// it will return an io.EOF
+// example if the Decoder's [io.Reader] never had any bytes),
+// it will return an [io.EOF].
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.

--- a/yaml.go
+++ b/yaml.go
@@ -112,7 +112,10 @@ func (dec *Decoder) KnownFields(enable bool) {
 }
 
 // Decode reads the next YAML-encoded value from its input
-// and stores it in the value pointed to by v.
+// and stores it in the value pointed to by v. If there are
+// no more yaml documents to decode (or there never was, for
+// example if the Decoder's io.Reader never had any bytes),
+// it will return an io.EOF
 //
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.


### PR DESCRIPTION
I was originally confused by the fact that this code produced an error:

```
	var test struct{}
	err := yaml.NewDecoder(bytes.NewReader([]byte(""))).Decode(&test)
	fmt.Println(test, err)
```

whereas this did not:
```
	var test struct{}
	err := yaml.Unmarshal([]byte(""), &test)
	fmt.Println(test, err)
```

See: https://go.dev/play/p/tM_jp90fjFx

However, when I looked closer, I realized that this was the intended behavior. `Decode()` decodes the "next" document until it can't find any more, which it then indicates via `io.EOF`. If it were to return `nil`, there'd be no way for the client of `Decode()` to know there were no more documents.

This change adds to the documentation so this is a bit clearer.

Closes: #805