### PR TITLE
Allow for custom struct tags such as `json`.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -318,11 +318,12 @@ type decoder struct {
 	stringMapType  reflect.Type
 	generalMapType reflect.Type
 
-	knownFields bool
-	uniqueKeys  bool
-	decodeCount int
-	aliasCount  int
-	aliasDepth  int
+	knownFields   bool
+	uniqueKeys    bool
+	decodeCount   int
+	aliasCount    int
+	aliasDepth    int
+	structTagKeys []string
 
 	mergedFields map[interface{}]bool
 }
@@ -876,7 +877,7 @@ func isStringMap(n *Node) bool {
 }
 
 func (d *decoder) mappingStruct(n *Node, out reflect.Value) (good bool) {
-	sinfo, err := getStructInfo(out.Type())
+	sinfo, err := getStructInfo(out.Type(), d.structTagKeys)
 	if err != nil {
 		panic(err)
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -863,6 +863,33 @@ func (s *S) TestDecoderSingleDocument(c *C) {
 	}
 }
 
+func (s *S) TestDecoderUnmarshalJSONTags(c *C) {
+	type T struct {
+		Z int `json:"a"`
+		Y int `json:"b"`
+	}
+	var v T
+	decoder := yaml.NewDecoder(strings.NewReader("a: 1\nb: 2"))
+	decoder.SetStructTagKeys([]string{"json"})
+	err := decoder.Decode(&v)
+	c.Assert(err, IsNil)
+	c.Assert(v, DeepEquals, T{1, 2})
+}
+
+func (s *S) TestDecoderUnmarshalYAMLAndJSONTags(c *C) {
+	type T struct {
+		Z int `yaml:"a" json:"b"`
+		Y int `yaml:"b" json:"a"`
+		X int `json:"c"`
+	}
+	var v T
+	decoder := yaml.NewDecoder(strings.NewReader("a: 1\nb: 2\nc: 3"))
+	decoder.SetStructTagKeys([]string{"yaml", "json"})
+	err := decoder.Decode(&v)
+	c.Assert(err, IsNil)
+	c.Assert(v, DeepEquals, T{1, 2, 3})
+}
+
 var decoderTests = []struct {
 	data   string
 	values []interface{}

--- a/encode.go
+++ b/encode.go
@@ -29,12 +29,13 @@ import (
 )
 
 type encoder struct {
-	emitter  yaml_emitter_t
-	event    yaml_event_t
-	out      []byte
-	flow     bool
-	indent   int
-	doneInit bool
+	emitter       yaml_emitter_t
+	event         yaml_event_t
+	out           []byte
+	flow          bool
+	indent        int
+	doneInit      bool
+	structTagKeys []string
 }
 
 func newEncoder() *encoder {
@@ -212,7 +213,7 @@ func (e *encoder) fieldByIndex(v reflect.Value, index []int) (field reflect.Valu
 }
 
 func (e *encoder) structv(tag string, in reflect.Value) {
-	sinfo, err := getStructInfo(in.Type())
+	sinfo, err := getStructInfo(in.Type(), e.structTagKeys)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This is useful when using structs from 3rd-party packages which almost certainly only have `json` tags and not `yaml` tags.

This implementation does not change the default behavior for only looking for `yaml` tags, but allows the user to specify a list of tags to consider such as []string{"yaml", "json"} in an encoder or decoder.