### PR TITLE
Fix simple key handling

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -997,7 +997,7 @@ func yaml_emitter_check_simple_key(emitter *yaml_emitter_t) bool {
 	default:
 		return false
 	}
-	return length <= 128
+	return length <= 1024
 }
 
 // Determine an acceptable scalar style.


### PR DESCRIPTION
Currently if a key is more than 128 characters, it is handled as a complex mapping key, however this goes against the YAML spec as pointed out in https://github.com/go-yaml/yaml/issues/849#issuecomment-1215231786 . Can be read here: https://yaml.org/spec/1.2.2/#flow-mappings

This causes issues when handling OpenAPI specifications with paths longer than 128 characters, making them invalid.

This PR aims to fix this issue, which is also affecting yq as can be seen here https://github.com/mikefarah/yq/issues/1192

Fixes #849 