### PR TITLE
fix: decode !!binary as []byte

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -575,7 +575,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			if err != nil {
 				failf("!!binary value contains invalid base64 data")
 			}
-			resolved = string(data)
+			resolved = data
 		}
 	}
 	if resolved == nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -633,13 +633,13 @@ var unmarshalTests = []struct {
 	// Binary data.
 	{
 		"a: !!binary gIGC\n",
-		map[string]string{"a": "\x80\x81\x82"},
+		map[string][]byte{"a": []byte{0x80, 0x81, 0x82}},
 	}, {
 		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
-		map[string]string{"a": strings.Repeat("\x90", 54)},
+		map[string][]byte{"a": bytes.Repeat([]byte{0x90}, 54)},
 	}, {
 		"a: !!binary |\n  " + strings.Repeat("A", 70) + "\n  ==\n",
-		map[string]string{"a": strings.Repeat("\x00", 52)},
+		map[string][]byte{"a": bytes.Repeat([]byte{0x00}, 52)},
 	},
 
 	// Issue #39.

--- a/node_test.go
+++ b/node_test.go
@@ -2689,15 +2689,7 @@ var setStringTests = []struct {
 			Tag:   "!!str",
 			Style: yaml.LiteralStyle,
 		},
-	}, {
-		"\x80\x81\x82",
-		"!!binary gIGC\n",
-		yaml.Node{
-			Kind:  yaml.ScalarNode,
-			Value: "gIGC",
-			Tag:   "!!binary",
-		},
-	},
+	}, 
 }
 
 func (s *S) TestSetString(c *C) {


### PR DESCRIPTION
When decoding !!binary do not assume that the result will be a string, as !!binary can be use to encode arbitrary data.