### PR TITLE
Fix encoding for explicitly marked str nodes

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -447,11 +447,13 @@ func (e *encoder) node(node *Node, tail string) {
 				tag = ""
 			} else {
 				rtag, _ := resolve("", node.Value)
-				if rtag == stag {
+				if stag == strTag {
 					tag = ""
-				} else if stag == strTag {
+					if rtag != stag || isBase60Float(node.Value) || isOldBool(node.Value) {
+						forceQuoting = true
+					}
+				} else if stag == rtag {
 					tag = ""
-					forceQuoting = true
 				}
 			}
 		} else {

--- a/encode_test.go
+++ b/encode_test.go
@@ -494,6 +494,32 @@ var marshalTests = []struct {
 		},
 		"value: !!seq []\n",
 	},
+
+	// Enforced string nodes quoting with old-style booleans
+	{
+		&struct {
+			Value yaml.Node
+		}{
+			yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: "y",
+				Tag:   "!!str",
+			},
+		},
+		"value: \"y\"\n",
+	},
+	{
+		&struct {
+			Value yaml.Node
+		}{
+			yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: "yes",
+				Tag:   "!!str",
+			},
+		},
+		"value: \"yes\"\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {


### PR DESCRIPTION
When yaml.v3 encodes string nodes, that are explicitly marked with tag "!!str", it can remove this tag. But with ambiguous values like "y", "yes", "no" etc. it can lead to the result YAML document to be misinterpreted by YAML 1.1 compatible parsers.
This patch enforces old-boolean-like string nodes to be forcedly quoted. 